### PR TITLE
Update to v1.2.0

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -12,6 +12,10 @@ extends:
   - 'plugin:@typescript-eslint/recommended'
   - 'plugin:prettier/recommended'
 rules:
+  'prettier/prettier':
+    - "error"
+    - {}
+    - { usePrettierrc: true }
   'no-constant-condition': 'off'
 ignorePatterns:
   - 'node_modules'

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -6,10 +6,11 @@ parserOptions:
 plugins:
   - '@typescript-eslint'
   - 'prettier'
+  - 'eslint-plugin-prettier'
 extends:
   - 'eslint:recommended'
   - 'plugin:@typescript-eslint/recommended'
-  - 'prettier'
+  - 'plugin:prettier/recommended'
 rules:
   'no-constant-condition': 'off'
 ignorePatterns:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,8 @@
-name: Checks
-
+name: Release
+# TODO: finish script
+# TODO: add proper caching between jobs
 on:
-  workflow_dispatch:
-  pull_request:
+  push:
     branches: [ "main" ]
 
 jobs:

--- a/__tests__/commands/bin.ts
+++ b/__tests__/commands/bin.ts
@@ -20,6 +20,7 @@ const testSuite: CommandTestSuite = {
     },
     {
       input: ['unpm bin --global', 'unpm bin -g'],
+      globalPm: true,
       expected: {
         [PackageManager.NPM]: {
           expectedGeneratedCommand: 'npm bin --global',

--- a/__tests__/commands/install.ts
+++ b/__tests__/commands/install.ts
@@ -147,6 +147,7 @@ const testSuite: CommandTestSuite = {
         'unpm install express --global',
         'unpm install express -g',
       ],
+      globalPm: true,
       expected: {
         [PackageManager.NPM]: {
           expectedGeneratedCommand: 'npm install express --global',

--- a/__tests__/commands/licenses.ts
+++ b/__tests__/commands/licenses.ts
@@ -14,7 +14,7 @@ const testSuite: CommandTestSuite = {
           expectedGeneratedCommand: 'yarn licenses list',
         },
         [PackageManager.PNPM]: {
-          expectedGeneratedCommand: 'pnpm licenses',
+          expectedGeneratedCommand: 'pnpm licenses list',
         },
       },
     },

--- a/__tests__/commands/list.ts
+++ b/__tests__/commands/list.ts
@@ -34,6 +34,7 @@ const testSuite: CommandTestSuite = {
     },
     {
       input: ['unpm list --global', 'unpm list -g'],
+      globalPm: true,
       expected: {
         [PackageManager.NPM]: {
           expectedGeneratedCommand: 'npm ls --global',

--- a/__tests__/commands/outdated.ts
+++ b/__tests__/commands/outdated.ts
@@ -48,6 +48,7 @@ const testSuite: CommandTestSuite = {
     },
     {
       input: ['unpm outdated --global', 'unpm outdated -g'],
+      globalPm: true,
       expected: {
         [PackageManager.NPM]: {
           expectedGeneratedCommand: 'npm outdated --global',

--- a/__tests__/commands/uninstall.ts
+++ b/__tests__/commands/uninstall.ts
@@ -54,6 +54,7 @@ const testSuite: CommandTestSuite = {
     },
     {
       input: ['unpm remove ts-node --global', 'unpm remove ts-node -g'],
+      globalPm: true,
       expected: {
         [PackageManager.NPM]: {
           expectedGeneratedCommand: 'npm uninstall ts-node --global',

--- a/__tests__/commands/update.ts
+++ b/__tests__/commands/update.ts
@@ -66,6 +66,7 @@ const testSuite: CommandTestSuite = {
     },
     {
       input: ['unpm update ts-node --global', 'unpm update ts-node -g'],
+      globalPm: true,
       expected: {
         [PackageManager.NPM]: {
           expectedGeneratedCommand: 'npm update ts-node --global',

--- a/__tests__/types.ts
+++ b/__tests__/types.ts
@@ -1,4 +1,4 @@
-import { PackageManager } from "../src/enums";
+import { PackageManager } from "../src/packageManager/packageManager";
 
 export interface TestCaseOutcome__Success {
   expectedGeneratedCommand: string | RegExp | ((value: string) => boolean);
@@ -12,6 +12,7 @@ export type TestCaseOutcome = TestCaseOutcome__Success | TestCaseOutcome__Fail;
 
 export interface TestCase {
   input: string | string[];
+  globalPm?: boolean;
   expected: Record<PackageManager, TestCaseOutcome>;
 }
 

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,8 +1,9 @@
-const fs = require('fs');
+import type { Config } from '@jest/types';
+import { readFileSync } from 'fs';
 
-const swcConfig = JSON.parse(fs.readFileSync(`${__dirname}/.swcrc`, "utf-8"));
+const swcConfig = JSON.parse(readFileSync(`${__dirname}/.swcrc`, 'utf-8'));
 
-module.exports = {
+const config: Config.InitialOptions = {
   testMatch: [
     "**/*.test.ts",
   ],
@@ -18,4 +19,5 @@ module.exports = {
   },
   testEnvironment: 'node',
 };
- 
+
+export default config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "universal-npm",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "universal-npm",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/helpers": "^0.5.0",
@@ -18,6 +18,7 @@
         "unpm": "dist/bin/unpm.js"
       },
       "devDependencies": {
+        "@jest/types": "^29.5.0",
         "@swc/cli": "^0.1.62",
         "@swc/core": "^1.3.44",
         "@swc/jest": "^0.2.24",
@@ -990,23 +991,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/@jest/console/node_modules/@jest/types": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.5.0.tgz",
-      "integrity": "sha512-qbu7kN6czmVRc3xWFQcAN03RAUamgppVUdXrvl1Wr3jlNF93o9mJbGcDWrwGB6ht44u7efB1qCFgVQmca24Uog==",
-      "dev": true,
-      "dependencies": {
-        "@jest/schemas": "^29.4.3",
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.8",
-        "chalk": "^4.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
     "node_modules/@jest/core": {
       "version": "29.5.0",
       "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.5.0.tgz",
@@ -1054,23 +1038,6 @@
         }
       }
     },
-    "node_modules/@jest/core/node_modules/@jest/types": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.5.0.tgz",
-      "integrity": "sha512-qbu7kN6czmVRc3xWFQcAN03RAUamgppVUdXrvl1Wr3jlNF93o9mJbGcDWrwGB6ht44u7efB1qCFgVQmca24Uog==",
-      "dev": true,
-      "dependencies": {
-        "@jest/schemas": "^29.4.3",
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.8",
-        "chalk": "^4.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
     "node_modules/@jest/create-cache-key-function": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/@jest/create-cache-key-function/-/create-cache-key-function-27.5.1.tgz",
@@ -1083,6 +1050,31 @@
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
+    "node_modules/@jest/create-cache-key-function/node_modules/@jest/types": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.5.1.tgz",
+      "integrity": "sha512-Cx46iJ9QpwQTjIdq5VJu2QTMMs3QlEjI0x1QbBP5W1+nMzyc2XmimiRR/CbX9TO0cPTeUlxWMOu8mslYsJ8DEw==",
+      "dev": true,
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^16.0.0",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@jest/create-cache-key-function/node_modules/@types/yargs": {
+      "version": "16.0.5",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.5.tgz",
+      "integrity": "sha512-AxO/ADJOBFJScHbWhq2xAhlWP24rY4aCEG/NFaMvbT3X2MgRsLjhjQwsn0Zi5zn0LG9jUhCCZMeX9Dkuw6k+vQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
     "node_modules/@jest/environment": {
       "version": "29.5.0",
       "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.5.0.tgz",
@@ -1093,23 +1085,6 @@
         "@jest/types": "^29.5.0",
         "@types/node": "*",
         "jest-mock": "^29.5.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@jest/environment/node_modules/@jest/types": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.5.0.tgz",
-      "integrity": "sha512-qbu7kN6czmVRc3xWFQcAN03RAUamgppVUdXrvl1Wr3jlNF93o9mJbGcDWrwGB6ht44u7efB1qCFgVQmca24Uog==",
-      "dev": true,
-      "dependencies": {
-        "@jest/schemas": "^29.4.3",
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.8",
-        "chalk": "^4.0.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -1157,23 +1132,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/@jest/fake-timers/node_modules/@jest/types": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.5.0.tgz",
-      "integrity": "sha512-qbu7kN6czmVRc3xWFQcAN03RAUamgppVUdXrvl1Wr3jlNF93o9mJbGcDWrwGB6ht44u7efB1qCFgVQmca24Uog==",
-      "dev": true,
-      "dependencies": {
-        "@jest/schemas": "^29.4.3",
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.8",
-        "chalk": "^4.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
     "node_modules/@jest/globals": {
       "version": "29.5.0",
       "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.5.0.tgz",
@@ -1184,23 +1142,6 @@
         "@jest/expect": "^29.5.0",
         "@jest/types": "^29.5.0",
         "jest-mock": "^29.5.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@jest/globals/node_modules/@jest/types": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.5.0.tgz",
-      "integrity": "sha512-qbu7kN6czmVRc3xWFQcAN03RAUamgppVUdXrvl1Wr3jlNF93o9mJbGcDWrwGB6ht44u7efB1qCFgVQmca24Uog==",
-      "dev": true,
-      "dependencies": {
-        "@jest/schemas": "^29.4.3",
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.8",
-        "chalk": "^4.0.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -1247,23 +1188,6 @@
         "node-notifier": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@jest/reporters/node_modules/@jest/types": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.5.0.tgz",
-      "integrity": "sha512-qbu7kN6czmVRc3xWFQcAN03RAUamgppVUdXrvl1Wr3jlNF93o9mJbGcDWrwGB6ht44u7efB1qCFgVQmca24Uog==",
-      "dev": true,
-      "dependencies": {
-        "@jest/schemas": "^29.4.3",
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.8",
-        "chalk": "^4.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jest/reporters/node_modules/@jridgewell/trace-mapping": {
@@ -1327,23 +1251,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/@jest/test-result/node_modules/@jest/types": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.5.0.tgz",
-      "integrity": "sha512-qbu7kN6czmVRc3xWFQcAN03RAUamgppVUdXrvl1Wr3jlNF93o9mJbGcDWrwGB6ht44u7efB1qCFgVQmca24Uog==",
-      "dev": true,
-      "dependencies": {
-        "@jest/schemas": "^29.4.3",
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.8",
-        "chalk": "^4.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
     "node_modules/@jest/test-sequencer": {
       "version": "29.5.0",
       "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.5.0.tgz",
@@ -1385,7 +1292,17 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/@jest/transform/node_modules/@jest/types": {
+    "node_modules/@jest/transform/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.17",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz",
+      "integrity": "sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "3.1.0",
+        "@jridgewell/sourcemap-codec": "1.4.14"
+      }
+    },
+    "node_modules/@jest/types": {
       "version": "29.5.0",
       "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.5.0.tgz",
       "integrity": "sha512-qbu7kN6czmVRc3xWFQcAN03RAUamgppVUdXrvl1Wr3jlNF93o9mJbGcDWrwGB6ht44u7efB1qCFgVQmca24Uog==",
@@ -1400,41 +1317,6 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@jest/transform/node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.17",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz",
-      "integrity": "sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==",
-      "dev": true,
-      "dependencies": {
-        "@jridgewell/resolve-uri": "3.1.0",
-        "@jridgewell/sourcemap-codec": "1.4.14"
-      }
-    },
-    "node_modules/@jest/types": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.5.1.tgz",
-      "integrity": "sha512-Cx46iJ9QpwQTjIdq5VJu2QTMMs3QlEjI0x1QbBP5W1+nMzyc2XmimiRR/CbX9TO0cPTeUlxWMOu8mslYsJ8DEw==",
-      "dev": true,
-      "dependencies": {
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "*",
-        "@types/yargs": "^16.0.0",
-        "chalk": "^4.0.0"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "node_modules/@jest/types/node_modules/@types/yargs": {
-      "version": "16.0.5",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.5.tgz",
-      "integrity": "sha512-AxO/ADJOBFJScHbWhq2xAhlWP24rY4aCEG/NFaMvbT3X2MgRsLjhjQwsn0Zi5zn0LG9jUhCCZMeX9Dkuw6k+vQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/yargs-parser": "*"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -4867,23 +4749,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/jest-circus/node_modules/@jest/types": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.5.0.tgz",
-      "integrity": "sha512-qbu7kN6czmVRc3xWFQcAN03RAUamgppVUdXrvl1Wr3jlNF93o9mJbGcDWrwGB6ht44u7efB1qCFgVQmca24Uog==",
-      "dev": true,
-      "dependencies": {
-        "@jest/schemas": "^29.4.3",
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.8",
-        "chalk": "^4.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
     "node_modules/jest-cli": {
       "version": "29.5.0",
       "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.5.0.tgz",
@@ -4916,23 +4781,6 @@
         "node-notifier": {
           "optional": true
         }
-      }
-    },
-    "node_modules/jest-cli/node_modules/@jest/types": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.5.0.tgz",
-      "integrity": "sha512-qbu7kN6czmVRc3xWFQcAN03RAUamgppVUdXrvl1Wr3jlNF93o9mJbGcDWrwGB6ht44u7efB1qCFgVQmca24Uog==",
-      "dev": true,
-      "dependencies": {
-        "@jest/schemas": "^29.4.3",
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.8",
-        "chalk": "^4.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-config": {
@@ -4980,23 +4828,6 @@
         }
       }
     },
-    "node_modules/jest-config/node_modules/@jest/types": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.5.0.tgz",
-      "integrity": "sha512-qbu7kN6czmVRc3xWFQcAN03RAUamgppVUdXrvl1Wr3jlNF93o9mJbGcDWrwGB6ht44u7efB1qCFgVQmca24Uog==",
-      "dev": true,
-      "dependencies": {
-        "@jest/schemas": "^29.4.3",
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.8",
-        "chalk": "^4.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
     "node_modules/jest-diff": {
       "version": "29.5.0",
       "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.5.0.tgz",
@@ -5040,23 +4871,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/jest-each/node_modules/@jest/types": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.5.0.tgz",
-      "integrity": "sha512-qbu7kN6czmVRc3xWFQcAN03RAUamgppVUdXrvl1Wr3jlNF93o9mJbGcDWrwGB6ht44u7efB1qCFgVQmca24Uog==",
-      "dev": true,
-      "dependencies": {
-        "@jest/schemas": "^29.4.3",
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.8",
-        "chalk": "^4.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
     "node_modules/jest-environment-node": {
       "version": "29.5.0",
       "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.5.0.tgz",
@@ -5069,23 +4883,6 @@
         "@types/node": "*",
         "jest-mock": "^29.5.0",
         "jest-util": "^29.5.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-environment-node/node_modules/@jest/types": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.5.0.tgz",
-      "integrity": "sha512-qbu7kN6czmVRc3xWFQcAN03RAUamgppVUdXrvl1Wr3jlNF93o9mJbGcDWrwGB6ht44u7efB1qCFgVQmca24Uog==",
-      "dev": true,
-      "dependencies": {
-        "@jest/schemas": "^29.4.3",
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.8",
-        "chalk": "^4.0.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -5123,23 +4920,6 @@
       },
       "optionalDependencies": {
         "fsevents": "^2.3.2"
-      }
-    },
-    "node_modules/jest-haste-map/node_modules/@jest/types": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.5.0.tgz",
-      "integrity": "sha512-qbu7kN6czmVRc3xWFQcAN03RAUamgppVUdXrvl1Wr3jlNF93o9mJbGcDWrwGB6ht44u7efB1qCFgVQmca24Uog==",
-      "dev": true,
-      "dependencies": {
-        "@jest/schemas": "^29.4.3",
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.8",
-        "chalk": "^4.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-leak-detector": {
@@ -5190,23 +4970,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/jest-message-util/node_modules/@jest/types": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.5.0.tgz",
-      "integrity": "sha512-qbu7kN6czmVRc3xWFQcAN03RAUamgppVUdXrvl1Wr3jlNF93o9mJbGcDWrwGB6ht44u7efB1qCFgVQmca24Uog==",
-      "dev": true,
-      "dependencies": {
-        "@jest/schemas": "^29.4.3",
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.8",
-        "chalk": "^4.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
     "node_modules/jest-mock": {
       "version": "29.5.0",
       "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.5.0.tgz",
@@ -5216,23 +4979,6 @@
         "@jest/types": "^29.5.0",
         "@types/node": "*",
         "jest-util": "^29.5.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-mock/node_modules/@jest/types": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.5.0.tgz",
-      "integrity": "sha512-qbu7kN6czmVRc3xWFQcAN03RAUamgppVUdXrvl1Wr3jlNF93o9mJbGcDWrwGB6ht44u7efB1qCFgVQmca24Uog==",
-      "dev": true,
-      "dependencies": {
-        "@jest/schemas": "^29.4.3",
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.8",
-        "chalk": "^4.0.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -5329,23 +5075,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/jest-runner/node_modules/@jest/types": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.5.0.tgz",
-      "integrity": "sha512-qbu7kN6czmVRc3xWFQcAN03RAUamgppVUdXrvl1Wr3jlNF93o9mJbGcDWrwGB6ht44u7efB1qCFgVQmca24Uog==",
-      "dev": true,
-      "dependencies": {
-        "@jest/schemas": "^29.4.3",
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.8",
-        "chalk": "^4.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
     "node_modules/jest-runtime": {
       "version": "29.5.0",
       "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.5.0.tgz",
@@ -5374,23 +5103,6 @@
         "jest-util": "^29.5.0",
         "slash": "^3.0.0",
         "strip-bom": "^4.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-runtime/node_modules/@jest/types": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.5.0.tgz",
-      "integrity": "sha512-qbu7kN6czmVRc3xWFQcAN03RAUamgppVUdXrvl1Wr3jlNF93o9mJbGcDWrwGB6ht44u7efB1qCFgVQmca24Uog==",
-      "dev": true,
-      "dependencies": {
-        "@jest/schemas": "^29.4.3",
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.8",
-        "chalk": "^4.0.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -5434,23 +5146,6 @@
         "natural-compare": "^1.4.0",
         "pretty-format": "^29.5.0",
         "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-snapshot/node_modules/@jest/types": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.5.0.tgz",
-      "integrity": "sha512-qbu7kN6czmVRc3xWFQcAN03RAUamgppVUdXrvl1Wr3jlNF93o9mJbGcDWrwGB6ht44u7efB1qCFgVQmca24Uog==",
-      "dev": true,
-      "dependencies": {
-        "@jest/schemas": "^29.4.3",
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.8",
-        "chalk": "^4.0.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -5506,23 +5201,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/jest-util/node_modules/@jest/types": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.5.0.tgz",
-      "integrity": "sha512-qbu7kN6czmVRc3xWFQcAN03RAUamgppVUdXrvl1Wr3jlNF93o9mJbGcDWrwGB6ht44u7efB1qCFgVQmca24Uog==",
-      "dev": true,
-      "dependencies": {
-        "@jest/schemas": "^29.4.3",
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.8",
-        "chalk": "^4.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
     "node_modules/jest-validate": {
       "version": "29.5.0",
       "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.5.0.tgz",
@@ -5535,23 +5213,6 @@
         "jest-get-type": "^29.4.3",
         "leven": "^3.1.0",
         "pretty-format": "^29.5.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-validate/node_modules/@jest/types": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.5.0.tgz",
-      "integrity": "sha512-qbu7kN6czmVRc3xWFQcAN03RAUamgppVUdXrvl1Wr3jlNF93o9mJbGcDWrwGB6ht44u7efB1qCFgVQmca24Uog==",
-      "dev": true,
-      "dependencies": {
-        "@jest/schemas": "^29.4.3",
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.8",
-        "chalk": "^4.0.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -5583,23 +5244,6 @@
         "emittery": "^0.13.1",
         "jest-util": "^29.5.0",
         "string-length": "^4.0.1"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-watcher/node_modules/@jest/types": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.5.0.tgz",
-      "integrity": "sha512-qbu7kN6czmVRc3xWFQcAN03RAUamgppVUdXrvl1Wr3jlNF93o9mJbGcDWrwGB6ht44u7efB1qCFgVQmca24Uog==",
-      "dev": true,
-      "dependencies": {
-        "@jest/schemas": "^29.4.3",
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.8",
-        "chalk": "^4.0.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -5642,23 +5286,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
-    "node_modules/jest/node_modules/@jest/types": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.5.0.tgz",
-      "integrity": "sha512-qbu7kN6czmVRc3xWFQcAN03RAUamgppVUdXrvl1Wr3jlNF93o9mJbGcDWrwGB6ht44u7efB1qCFgVQmca24Uog==",
-      "dev": true,
-      "dependencies": {
-        "@jest/schemas": "^29.4.3",
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.8",
-        "chalk": "^4.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/js-sdsl": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "unpm": "dist/bin/unpm.js"
   },
   "devDependencies": {
+    "@jest/types": "^29.5.0",
     "@swc/cli": "^0.1.62",
     "@swc/core": "^1.3.44",
     "@swc/jest": "^0.2.24",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "universal-npm",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Universal Node.js Package Manager",
   "license": "Apache-2.0",
   "author": "wmdanor",

--- a/scripts/create-command.ts
+++ b/scripts/create-command.ts
@@ -16,10 +16,13 @@ async function getCommandName(): Promise<string> {
   const { createInterface } = await import('readline');
 
   const rl = createInterface({ input: process.stdin, output: process.stdout });
-  const prompt = (query: string) => new Promise<string>(resolve => rl.question(query, resolve));
+  const prompt = (query: string) =>
+    new Promise<string>(resolve => rl.question(query, resolve));
 
   while (true) {
-    const commandName = await prompt('Enter the command name: ').then(s => s.trim());
+    const commandName = await prompt('Enter the command name: ').then(s =>
+      s.trim(),
+    );
 
     if (commandName?.length > 0) {
       rl.close();
@@ -49,8 +52,14 @@ export async function createCommandFile(commandName: string): Promise<void> {
   const templateFileLocation = resolve(commandsFolderLocation, '_template.ts');
   const templateFileContent = await readFile(templateFileLocation, 'utf-8');
 
-  const commandFileLocation = resolve(commandsFolderLocation, commandName + '.ts');
-  const commandFileContent = templateFileContent.replace('{{command}}', commandName);
+  const commandFileLocation = resolve(
+    commandsFolderLocation,
+    commandName + '.ts',
+  );
+  const commandFileContent = templateFileContent.replace(
+    '{{command}}',
+    commandName,
+  );
   await writeFile(commandFileLocation, commandFileContent, 'utf-8');
 }
 

--- a/scripts/pregenerate-files.ts
+++ b/scripts/pregenerate-files.ts
@@ -7,7 +7,13 @@ export async function execute() {
 
   let yargsLocal = yargs
     .scriptName('unpm')
+    .help('h')
+    .alias('help', 'h')
     .parserConfiguration({ 'unknown-options-as-args': true })
+    .example('$0', 'Install all packages in the project')
+    .example('$0 install express', 'Install express package')
+    .example('$0 add nodemon --dev', 'Install nodemon package as devDependency')
+    .example('$0 dev', 'Run "dev" script')
 
   const commandsLocations = resolve(__dirname, '../dist/commands');
   const commandsFiles = await readdir(commandsLocations);

--- a/scripts/pregenerate-files.ts
+++ b/scripts/pregenerate-files.ts
@@ -13,7 +13,7 @@ export async function execute() {
     .example('$0', 'Install all packages in the project')
     .example('$0 install express', 'Install express package')
     .example('$0 add nodemon --dev', 'Install nodemon package as devDependency')
-    .example('$0 dev', 'Run "dev" script')
+    .example('$0 dev', 'Run "dev" script');
 
   const commandsLocations = resolve(__dirname, '../dist/commands');
   const commandsFiles = await readdir(commandsLocations);
@@ -22,8 +22,10 @@ export async function execute() {
 
   for (const commandFile of commandsFiles) {
     const commandName = commandFile.replace(/\..*/, '');
-    
-    const commandModule = await import(`../dist/commands/${commandFile}`).then(m => m.default)
+
+    const commandModule = await import(`../dist/commands/${commandFile}`).then(
+      m => m.default,
+    );
 
     commandsMap[commandName] = commandName;
 
@@ -37,7 +39,9 @@ export async function execute() {
   }
 
   const generatedFolderLocation = resolve(__dirname, '../generated');
-  await access(generatedFolderLocation).catch(() => mkdir(generatedFolderLocation));
+  await access(generatedFolderLocation).catch(() =>
+    mkdir(generatedFolderLocation),
+  );
 
   const helpFileLocation = resolve(generatedFolderLocation, 'help.txt');
   const helpText = await yargsLocal.getHelp();
@@ -46,7 +50,7 @@ export async function execute() {
   const commandsMapFileLocation = resolve(
     generatedFolderLocation,
     'commandsMap.json',
-  )
+  );
   await writeFile(commandsMapFileLocation, JSON.stringify(commandsMap));
 
   // version.txt

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -33,16 +33,6 @@ function prompt(query: string): Promise<string> {
 }
 
 export async function execute() {
-  console.log('Release script started');
-
-  const releaseType = process.argv[2] ?? await prompt('Input release type [major | minor | patch]: ');
-
-  if (!['major', 'minor', 'patch'].includes(releaseType)) {
-    console.error('Release type can be only be one of [major | minor | patch], you entered:', releaseType);
-
-    exit(1);
-  }
-
   console.log('Running checks:');
 
   await execPipe('npm run typecheck');
@@ -55,8 +45,6 @@ export async function execute() {
     
     exit(0);
   }
-
-  await execPipe(`npm version ${releaseType}`);
 
   await execPipe('npm run build');
 

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -7,7 +7,7 @@ function exit(code = 0) {
 
 function execPipe(command: string): Promise<void> {
   console.log('Running:', command);
-  
+
   return new Promise((resolve, reject) => {
     const childProcess = exec(command, (error, stdout, stderr) => {
       if (error) {
@@ -19,7 +19,7 @@ function execPipe(command: string): Promise<void> {
 
     childProcess.stdout?.pipe(process.stdout);
     childProcess.stderr?.pipe(process.stderr);
-  })
+  });
 }
 
 function prompt(query: string): Promise<string> {
@@ -38,11 +38,13 @@ export async function execute() {
   await execPipe('npm run typecheck');
   await execPipe('npm run lint');
 
-  const confirmation = await prompt('Checks passed, do you want to proceed with release (y/n)? ');
+  const confirmation = await prompt(
+    'Checks passed, do you want to proceed with release (y/n)? ',
+  );
 
   if (!confirmation.toLocaleLowerCase().startsWith('y')) {
     console.log('Aborting release');
-    
+
     exit(0);
   }
 

--- a/src/bin/unpm.test.ts
+++ b/src/bin/unpm.test.ts
@@ -1,7 +1,7 @@
 import { execute } from './unpm';
 import runUnpmEntryPoint from '../entryPoints/unpm';
 import { NotSupportedError } from '../errors/NotSupportedError';
-import { PackageManager } from "../packageManager/packageManager";
+import { PackageManager } from '../packageManager/packageManager';
 import { printError } from '../io/printError';
 import { exit } from '../process/exit';
 
@@ -33,7 +33,9 @@ describe('bin/unpm', () => {
 
     await execute(process.argv);
 
-    expect(printErrorMock).toHaveBeenCalledWith(`${NotSupportedError.name}: "licenses" is not supported by ${PackageManager.NPM}`);
+    expect(printErrorMock).toHaveBeenCalledWith(
+      `${NotSupportedError.name}: "licenses" is not supported by ${PackageManager.NPM}`,
+    );
     expect(exitMock).toHaveBeenCalledWith('error');
   });
 

--- a/src/bin/unpm.ts
+++ b/src/bin/unpm.ts
@@ -5,13 +5,13 @@ import { printError } from '../io/printError';
 import { exit } from '../process/exit';
 
 export async function execute(argv: string[]) {
-  await runUnpmEntryPoint(argv).catch((error) => {
+  await runUnpmEntryPoint(argv).catch(error => {
     if (error instanceof NotSupportedError) {
       printError(`${NotSupportedError.name}: ${error.message}`);
     } else {
       printError(`Error: ${error?.message ?? error}`);
     }
-  
+
     exit('error');
   });
 }

--- a/src/commandHandler/createBaseCommandHandler.test.ts
+++ b/src/commandHandler/createBaseCommandHandler.test.ts
@@ -4,14 +4,17 @@ import { PackageManager } from "../packageManager/packageManager";
 import { executeCommand } from '../io/executeCommand';
 import { CommandMetaOption, CommandMetaPositional, generateCommand } from '../commandHandler/generateCommand';
 import { getPackageManager } from '../packageManager/getPackageManager';
+import { getGlobalPackageManager } from '../packageManager/getGlobalPackageManager';
 
 jest.mock('../io/executeCommand');
 jest.mock('./generateCommand');
 jest.mock('../packageManager/getPackageManager');
+jest.mock('../packageManager/getGlobalPackageManager');
 
 const executeCommandMock = jest.mocked(executeCommand);
 const generateCommandMock = jest.mocked(generateCommand);
 const getPackageManagerMock = jest.mocked(getPackageManager);
+const getGlobalPackageManagerMock = jest.mocked(getGlobalPackageManager);
 
 describe('commandHandler/createBaseCommandHandler', () => {
   afterEach(() => {
@@ -42,5 +45,71 @@ describe('commandHandler/createBaseCommandHandler', () => {
     expect(generateCommandMock).toHaveBeenCalledWith({ packageManager, positionals: metaPositionals, options: metaOptions });
     expect(executeCommandMock).toHaveBeenCalledTimes(1);
     expect(executeCommandMock).toHaveBeenCalledWith('generated-command');
+  });
+});
+
+describe('commandHandler/createBaseCommandHandler/global', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('no global flag', () => {
+    it('should create and execute a command with the correct package manager and meta', async () => {
+      const packageManager = PackageManager.NPM;
+      const metaPositionals: CommandMetaPositional[] = [
+        { order: 1, value: 'positional1' },
+      ];
+      const metaOptions: CommandMetaOption[] = [
+        { name: 'option1', value: 'value1' },
+      ];
+  
+      getPackageManagerMock.mockResolvedValue(packageManager);
+      getGlobalPackageManagerMock.mockResolvedValue(packageManager);
+      generateCommandMock.mockReturnValue('generated-command');
+  
+      const metaConstructors = {
+        [PackageManager.NPM]: () => ({ positionals: metaPositionals, options: metaOptions }),
+      } as unknown as MetaConstructors;
+  
+      const baseCommandHandler = createBaseCommandHandler.global(metaConstructors);
+      await baseCommandHandler({ '$0': '', _: [] });
+  
+      expect(getPackageManagerMock).toHaveBeenCalledTimes(1);
+      expect(getGlobalPackageManager).toHaveBeenCalledTimes(0);
+      expect(generateCommandMock).toHaveBeenCalledTimes(1);
+      expect(generateCommandMock).toHaveBeenCalledWith({ packageManager, positionals: metaPositionals, options: metaOptions });
+      expect(executeCommandMock).toHaveBeenCalledTimes(1);
+      expect(executeCommandMock).toHaveBeenCalledWith('generated-command');
+    });
+  });
+
+  describe('global flag present', () => {
+    it('should create and execute a command with the correct package manager and meta', async () => {
+      const packageManager = PackageManager.NPM;
+      const metaPositionals: CommandMetaPositional[] = [
+        { order: 1, value: 'positional1' },
+      ];
+      const metaOptions: CommandMetaOption[] = [
+        { name: 'option1', value: 'value1' },
+      ];
+  
+      getPackageManagerMock.mockResolvedValue(packageManager);
+      getGlobalPackageManagerMock.mockResolvedValue(packageManager);
+      generateCommandMock.mockReturnValue('generated-command');
+  
+      const metaConstructors = {
+        [PackageManager.NPM]: () => ({ positionals: metaPositionals, options: metaOptions }),
+      } as unknown as MetaConstructors;
+  
+      const baseCommandHandler = createBaseCommandHandler.global(metaConstructors);
+      await baseCommandHandler({ '$0': '', _: [], global: true });
+  
+      expect(getPackageManagerMock).toHaveBeenCalledTimes(0);
+      expect(getGlobalPackageManager).toHaveBeenCalledTimes(1);
+      expect(generateCommandMock).toHaveBeenCalledTimes(1);
+      expect(generateCommandMock).toHaveBeenCalledWith({ packageManager, positionals: metaPositionals, options: metaOptions });
+      expect(executeCommandMock).toHaveBeenCalledTimes(1);
+      expect(executeCommandMock).toHaveBeenCalledWith('generated-command');
+    });
   });
 });

--- a/src/commandHandler/createBaseCommandHandler.test.ts
+++ b/src/commandHandler/createBaseCommandHandler.test.ts
@@ -1,8 +1,12 @@
 import { createBaseCommandHandler } from '../commandHandler/createBaseCommandHandler';
 import { MetaConstructors } from './types';
-import { PackageManager } from "../packageManager/packageManager";
+import { PackageManager } from '../packageManager/packageManager';
 import { executeCommand } from '../io/executeCommand';
-import { CommandMetaOption, CommandMetaPositional, generateCommand } from '../commandHandler/generateCommand';
+import {
+  CommandMetaOption,
+  CommandMetaPositional,
+  generateCommand,
+} from '../commandHandler/generateCommand';
 import { getPackageManager } from '../packageManager/getPackageManager';
 import { getGlobalPackageManager } from '../packageManager/getGlobalPackageManager';
 
@@ -34,15 +38,22 @@ describe('commandHandler/createBaseCommandHandler', () => {
     generateCommandMock.mockReturnValue('generated-command');
 
     const metaConstructors = {
-      [PackageManager.NPM]: () => ({ positionals: metaPositionals, options: metaOptions }),
+      [PackageManager.NPM]: () => ({
+        positionals: metaPositionals,
+        options: metaOptions,
+      }),
     } as unknown as MetaConstructors;
 
     const baseCommandHandler = createBaseCommandHandler(metaConstructors);
-    await baseCommandHandler({ '$0': '', _: [] });
+    await baseCommandHandler({ $0: '', _: [] });
 
     expect(getPackageManagerMock).toHaveBeenCalledTimes(1);
     expect(generateCommandMock).toHaveBeenCalledTimes(1);
-    expect(generateCommandMock).toHaveBeenCalledWith({ packageManager, positionals: metaPositionals, options: metaOptions });
+    expect(generateCommandMock).toHaveBeenCalledWith({
+      packageManager,
+      positionals: metaPositionals,
+      options: metaOptions,
+    });
     expect(executeCommandMock).toHaveBeenCalledTimes(1);
     expect(executeCommandMock).toHaveBeenCalledWith('generated-command');
   });
@@ -62,22 +73,30 @@ describe('commandHandler/createBaseCommandHandler/global', () => {
       const metaOptions: CommandMetaOption[] = [
         { name: 'option1', value: 'value1' },
       ];
-  
+
       getPackageManagerMock.mockResolvedValue(packageManager);
       getGlobalPackageManagerMock.mockResolvedValue(packageManager);
       generateCommandMock.mockReturnValue('generated-command');
-  
+
       const metaConstructors = {
-        [PackageManager.NPM]: () => ({ positionals: metaPositionals, options: metaOptions }),
+        [PackageManager.NPM]: () => ({
+          positionals: metaPositionals,
+          options: metaOptions,
+        }),
       } as unknown as MetaConstructors;
-  
-      const baseCommandHandler = createBaseCommandHandler.global(metaConstructors);
-      await baseCommandHandler({ '$0': '', _: [] });
-  
+
+      const baseCommandHandler =
+        createBaseCommandHandler.global(metaConstructors);
+      await baseCommandHandler({ $0: '', _: [] });
+
       expect(getPackageManagerMock).toHaveBeenCalledTimes(1);
       expect(getGlobalPackageManager).toHaveBeenCalledTimes(0);
       expect(generateCommandMock).toHaveBeenCalledTimes(1);
-      expect(generateCommandMock).toHaveBeenCalledWith({ packageManager, positionals: metaPositionals, options: metaOptions });
+      expect(generateCommandMock).toHaveBeenCalledWith({
+        packageManager,
+        positionals: metaPositionals,
+        options: metaOptions,
+      });
       expect(executeCommandMock).toHaveBeenCalledTimes(1);
       expect(executeCommandMock).toHaveBeenCalledWith('generated-command');
     });
@@ -92,22 +111,30 @@ describe('commandHandler/createBaseCommandHandler/global', () => {
       const metaOptions: CommandMetaOption[] = [
         { name: 'option1', value: 'value1' },
       ];
-  
+
       getPackageManagerMock.mockResolvedValue(packageManager);
       getGlobalPackageManagerMock.mockResolvedValue(packageManager);
       generateCommandMock.mockReturnValue('generated-command');
-  
+
       const metaConstructors = {
-        [PackageManager.NPM]: () => ({ positionals: metaPositionals, options: metaOptions }),
+        [PackageManager.NPM]: () => ({
+          positionals: metaPositionals,
+          options: metaOptions,
+        }),
       } as unknown as MetaConstructors;
-  
-      const baseCommandHandler = createBaseCommandHandler.global(metaConstructors);
-      await baseCommandHandler({ '$0': '', _: [], global: true });
-  
+
+      const baseCommandHandler =
+        createBaseCommandHandler.global(metaConstructors);
+      await baseCommandHandler({ $0: '', _: [], global: true });
+
       expect(getPackageManagerMock).toHaveBeenCalledTimes(0);
       expect(getGlobalPackageManager).toHaveBeenCalledTimes(1);
       expect(generateCommandMock).toHaveBeenCalledTimes(1);
-      expect(generateCommandMock).toHaveBeenCalledWith({ packageManager, positionals: metaPositionals, options: metaOptions });
+      expect(generateCommandMock).toHaveBeenCalledWith({
+        packageManager,
+        positionals: metaPositionals,
+        options: metaOptions,
+      });
       expect(executeCommandMock).toHaveBeenCalledTimes(1);
       expect(executeCommandMock).toHaveBeenCalledWith('generated-command');
     });

--- a/src/commandHandler/createBaseCommandHandler.ts
+++ b/src/commandHandler/createBaseCommandHandler.ts
@@ -2,9 +2,15 @@ import { MetaConstructors, MyCommandBuilder, MyCommandModuleU } from './types';
 import { executeCommand } from '../io/executeCommand';
 import { CommandMeta, generateCommand } from './generateCommand';
 
-export function createBaseCommandHandler<BuilderType extends MyCommandBuilder>(metaConstructors: MetaConstructors<BuilderType>) {
-  return async function baseCommandHandler(argv: MyCommandModuleU<BuilderType>) {
-    const { getPackageManager } = await import('../packageManager/getPackageManager');
+export function createBaseCommandHandler<BuilderType extends MyCommandBuilder>(
+  metaConstructors: MetaConstructors<BuilderType>,
+) {
+  return async function baseCommandHandler(
+    argv: MyCommandModuleU<BuilderType>,
+  ) {
+    const { getPackageManager } = await import(
+      '../packageManager/getPackageManager'
+    );
     const packageManager = await getPackageManager();
     const meta: CommandMeta = {
       packageManager,
@@ -14,16 +20,22 @@ export function createBaseCommandHandler<BuilderType extends MyCommandBuilder>(m
     const generatedCommand = generateCommand(meta);
 
     await executeCommand(generatedCommand);
-  }
+  };
 }
 
 createBaseCommandHandler.global = function createBaseCommandHandlerGlobal<
-  BuilderType extends MyCommandBuilder<unknown, { global?: boolean }>
+  BuilderType extends MyCommandBuilder<unknown, { global?: boolean }>,
 >(metaConstructors: MetaConstructors<BuilderType>) {
-  return async function baseCommandHandler(argv: MyCommandModuleU<BuilderType>) {
-    const getPackageManager = argv.global ?
-      await import('../packageManager/getGlobalPackageManager').then(m => m.getGlobalPackageManager) :
-      await import('../packageManager/getPackageManager').then(m => m.getPackageManager)
+  return async function baseCommandHandler(
+    argv: MyCommandModuleU<BuilderType>,
+  ) {
+    const getPackageManager = argv.global
+      ? await import('../packageManager/getGlobalPackageManager').then(
+          m => m.getGlobalPackageManager,
+        )
+      : await import('../packageManager/getPackageManager').then(
+          m => m.getPackageManager,
+        );
     const packageManager = await getPackageManager();
     const meta: CommandMeta = {
       packageManager,
@@ -33,5 +45,5 @@ createBaseCommandHandler.global = function createBaseCommandHandlerGlobal<
     const generatedCommand = generateCommand(meta);
 
     await executeCommand(generatedCommand);
-  }
-}
+  };
+};

--- a/src/commandHandler/createBaseCommandHandler.ts
+++ b/src/commandHandler/createBaseCommandHandler.ts
@@ -16,3 +16,22 @@ export function createBaseCommandHandler<BuilderType extends MyCommandBuilder>(m
     await executeCommand(generatedCommand);
   }
 }
+
+createBaseCommandHandler.global = function createBaseCommandHandlerGlobal<
+  BuilderType extends MyCommandBuilder<unknown, { global?: boolean }>
+>(metaConstructors: MetaConstructors<BuilderType>) {
+  return async function baseCommandHandler(argv: MyCommandModuleU<BuilderType>) {
+    const getPackageManager = argv.global ?
+      await import('../packageManager/getGlobalPackageManager').then(m => m.getGlobalPackageManager) :
+      await import('../packageManager/getPackageManager').then(m => m.getPackageManager)
+    const packageManager = await getPackageManager();
+    const meta: CommandMeta = {
+      packageManager,
+      ...metaConstructors[packageManager](argv),
+    };
+
+    const generatedCommand = generateCommand(meta);
+
+    await executeCommand(generatedCommand);
+  }
+}

--- a/src/commandHandler/generateCommand.test.ts
+++ b/src/commandHandler/generateCommand.test.ts
@@ -1,108 +1,108 @@
-import { generateCommand, CommandMeta } from "./generateCommand";
-import { PackageManager } from "../packageManager/packageManager";
+import { generateCommand, CommandMeta } from './generateCommand';
+import { PackageManager } from '../packageManager/packageManager';
 
-describe("commandHandler/generateCommand", () => {
+describe('commandHandler/generateCommand', () => {
   const baseMeta: CommandMeta = {
     packageManager: PackageManager.NPM,
     positionals: [],
     options: [],
   };
 
-  it("should generate command with package manager only", () => {
+  it('should generate command with package manager only', () => {
     const result = generateCommand(baseMeta);
-    expect(result).toBe("npm");
+    expect(result).toBe('npm');
   });
 
-  it("should generate command with positionals", () => {
+  it('should generate command with positionals', () => {
     const meta: CommandMeta = {
       ...baseMeta,
       positionals: [
-        { order: 1, value: "install" },
-        { order: 2, value: ["react", "react-dom"] },
+        { order: 1, value: 'install' },
+        { order: 2, value: ['react', 'react-dom'] },
         { order: 3, value: [] },
         { order: 4, value: undefined },
       ],
     };
 
     const result = generateCommand(meta);
-    expect(result).toBe("npm install react react-dom");
+    expect(result).toBe('npm install react react-dom');
   });
 
-  it("should generate command with options", () => {
+  it('should generate command with options', () => {
     const meta: CommandMeta = {
       ...baseMeta,
       options: [
-        { name: "--global", value: true },
-        { name: "--prefix", value: "/custom/path" },
+        { name: '--global', value: true },
+        { name: '--prefix', value: '/custom/path' },
       ],
     };
 
     const result = generateCommand(meta);
-    expect(result).toBe("npm --global --prefix=/custom/path");
+    expect(result).toBe('npm --global --prefix=/custom/path');
   });
 
-  it("should generate command with positionals and options", () => {
+  it('should generate command with positionals and options', () => {
     const meta: CommandMeta = {
       ...baseMeta,
-      positionals: [{ order: 1, value: "install" }],
+      positionals: [{ order: 1, value: 'install' }],
       options: [
-        { name: "--global", value: true },
-        { name: "--prefix", value: "/custom/path" },
+        { name: '--global', value: true },
+        { name: '--prefix', value: '/custom/path' },
       ],
     };
 
     const result = generateCommand(meta);
-    expect(result).toBe("npm install --global --prefix=/custom/path");
+    expect(result).toBe('npm install --global --prefix=/custom/path');
   });
 
-  it("should ignore positionals with false condition", () => {
+  it('should ignore positionals with false condition', () => {
     const meta: CommandMeta = {
       ...baseMeta,
       positionals: [
-        { order: 1, value: "install" },
-        { order: 2, value: "react", condition: false },
+        { order: 1, value: 'install' },
+        { order: 2, value: 'react', condition: false },
       ],
     };
 
     const result = generateCommand(meta);
-    expect(result).toBe("npm install");
+    expect(result).toBe('npm install');
   });
 
-  it("should ignore undefined options", () => {
+  it('should ignore undefined options', () => {
     const meta: CommandMeta = {
       ...baseMeta,
       options: [
-        { name: "--global", value: undefined },
-        { name: "--prefix", value: "/custom/path" },
+        { name: '--global', value: undefined },
+        { name: '--prefix', value: '/custom/path' },
       ],
     };
 
     const result = generateCommand(meta);
-    expect(result).toBe("npm --prefix=/custom/path");
+    expect(result).toBe('npm --prefix=/custom/path');
   });
 
-  it("should ignore null options", () => {
+  it('should ignore null options', () => {
     const meta: CommandMeta = {
       ...baseMeta,
       options: [
-        { name: "--global", value: null },
-        { name: "--prefix", value: "/custom/path" },
+        { name: '--global', value: null },
+        { name: '--prefix', value: '/custom/path' },
       ],
     };
 
     const result = generateCommand(meta);
-    expect(result).toBe("npm --prefix=/custom/path");
+    expect(result).toBe('npm --prefix=/custom/path');
   });
 
-  it("should handle different package managers", () => {
+  it('should handle different package managers', () => {
     const meta: CommandMeta = {
       ...baseMeta,
       packageManager: PackageManager.YARN,
-      positionals: [{ order: 1, value: "add" }],
-      options: [{ name: "--global", value: true }],
+      positionals: [{ order: 1, value: 'add' }],
+      options: [{ name: '--global', value: true }],
     };
 
     const result = generateCommand(meta);
-    expect(result).toBe("yarn add --global");
+    expect(result).toBe('yarn add --global');
   });
 });

--- a/src/commandHandler/generateCommand.ts
+++ b/src/commandHandler/generateCommand.ts
@@ -1,4 +1,4 @@
-import { PackageManager } from "../packageManager/packageManager";
+import { PackageManager } from '../packageManager/packageManager';
 
 export interface CommandMeta {
   packageManager: PackageManager;
@@ -31,12 +31,12 @@ export function generateCommand(meta: CommandMeta): string {
     if (v.value.length === 0) return false;
 
     return true;
-  }
+  };
 
   const sortedPositionals = meta.positionals
     .slice()
     .filter(predicate)
-    .sort((a, b) => a.order - b.order)
+    .sort((a, b) => a.order - b.order);
 
   for (const { value } of sortedPositionals) {
     if (Array.isArray(value)) {

--- a/src/commandHandler/runCommandModule.test.ts
+++ b/src/commandHandler/runCommandModule.test.ts
@@ -12,6 +12,7 @@ jest.mock('yargs/yargs', () => () => {
     help: jest.fn().mockReturnThis(),
     fail: jest.fn().mockReturnThis(),
     parseAsync: jest.fn().mockResolvedValue(undefined),
+    alias: jest.fn().mockReturnThis(),
   };
 
   yargsInstanceMock = yargsMock as unknown as Argv;
@@ -40,9 +41,10 @@ describe('commandHandler/runCommandModule', () => {
     expect(yargsInstanceMock.parserConfiguration).toHaveBeenCalledWith({ 'unknown-options-as-args': true });
     expect(yargsInstanceMock.command).toHaveBeenCalled();
     expect(yargsInstanceMock.version).toHaveBeenCalledWith(false);
-    expect(yargsInstanceMock.help).toHaveBeenCalled();
+    expect(yargsInstanceMock.help).toHaveBeenCalledWith('h');
     expect(yargsInstanceMock.fail).toHaveBeenCalled();
     expect(yargsInstanceMock.parseAsync).toHaveBeenCalled();
+    expect(yargsInstanceMock.alias).toHaveBeenCalledWith('help', 'h');
   });
 
   it('should reject when command module is not found', async () => {

--- a/src/commandHandler/runCommandModule.test.ts
+++ b/src/commandHandler/runCommandModule.test.ts
@@ -24,7 +24,9 @@ jest.mock('../commands/install', () => {
   const commandModule: CommandModule<unknown, unknown> = {
     command: 'test',
     describe: 'A test command',
-    handler: async () => { /* */ },
+    handler: async () => {
+      /* */
+    },
   };
   return { default: commandModule };
 });
@@ -38,7 +40,9 @@ describe('commandHandler/runCommandModule', () => {
     await runCommandModule(process.argv, 'install');
 
     expect(yargsInstanceMock.scriptName).toHaveBeenCalledWith('unpm');
-    expect(yargsInstanceMock.parserConfiguration).toHaveBeenCalledWith({ 'unknown-options-as-args': true });
+    expect(yargsInstanceMock.parserConfiguration).toHaveBeenCalledWith({
+      'unknown-options-as-args': true,
+    });
     expect(yargsInstanceMock.command).toHaveBeenCalled();
     expect(yargsInstanceMock.version).toHaveBeenCalledWith(false);
     expect(yargsInstanceMock.help).toHaveBeenCalledWith('h');
@@ -48,7 +52,9 @@ describe('commandHandler/runCommandModule', () => {
   });
 
   it('should reject when command module is not found', async () => {
-    await expect(runCommandModule(process.argv, 'non-existent-module')).rejects.toThrow(
+    await expect(
+      runCommandModule(process.argv, 'non-existent-module'),
+    ).rejects.toThrow(
       'Failed to load command module for "non-existent-module" command',
     );
   });

--- a/src/commandHandler/runCommandModule.ts
+++ b/src/commandHandler/runCommandModule.ts
@@ -10,7 +10,7 @@ export async function runCommandModule(argv: string[], commandName: string): Pro
     .command(commandModule)
     .version(false)
     .help('h')
-    .alias('help', 'h') // TODO: add test for this alias
+    .alias('help', 'h')
     .fail((message, error) => {
       throw error ?? new Error(message);
     })

--- a/src/commandHandler/runCommandModule.ts
+++ b/src/commandHandler/runCommandModule.ts
@@ -9,7 +9,8 @@ export async function runCommandModule(argv: string[], commandName: string): Pro
     .parserConfiguration({ 'unknown-options-as-args': true })
     .command(commandModule)
     .version(false)
-    .help()
+    .help('h')
+    .alias('help', 'h') // TODO: add test for this alias
     .fail((message, error) => {
       throw error ?? new Error(message);
     })

--- a/src/commandHandler/runCommandModule.ts
+++ b/src/commandHandler/runCommandModule.ts
@@ -1,7 +1,10 @@
 import yargsFactory from 'yargs/yargs';
 import { type CommandModule } from 'yargs';
 
-export async function runCommandModule(argv: string[], commandName: string): Promise<void> {
+export async function runCommandModule(
+  argv: string[],
+  commandName: string,
+): Promise<void> {
   const commandModule = await importCommandModule(commandName);
 
   await yargsFactory(argv.slice(2))
@@ -17,10 +20,14 @@ export async function runCommandModule(argv: string[], commandName: string): Pro
     .parseAsync();
 }
 
-async function importCommandModule(commandName: string): Promise<CommandModule<unknown, unknown>> {
+async function importCommandModule(
+  commandName: string,
+): Promise<CommandModule<unknown, unknown>> {
   try {
     return await import(`../commands/${commandName}`).then(m => m.default);
   } catch {
-    throw new Error(`Failed to load command module for "${commandName}" command`);
+    throw new Error(
+      `Failed to load command module for "${commandName}" command`,
+    );
   }
 }

--- a/src/commandHandler/types.ts
+++ b/src/commandHandler/types.ts
@@ -3,12 +3,26 @@ import type { CommandMeta } from './generateCommand';
 import type { PackageManager } from '../packageManager/packageManager';
 
 // eslint-disable-next-line @typescript-eslint/ban-types
-export type MyCommandBuilder<T = {}, U = {}> = Extract<CommandBuilder<T, U>, Function>;
-export type MyCommandModuleT<BuilderType extends MyCommandBuilder> = Parameters<BuilderType>[0];
-export type MyCommandModuleU<BuilderType extends MyCommandBuilder> = Exclude<Awaited<ReturnType<BuilderType>>['argv'], Promise<unknown>>;
-export type MyCommandModule<BuilderType extends MyCommandBuilder> = CommandModule<MyCommandModuleT<BuilderType>, MyCommandModuleU<BuilderType>>;
+export type MyCommandBuilder<T = {}, U = {}> = Extract<
+  CommandBuilder<T, U>,
+  Function
+>;
+export type MyCommandModuleT<BuilderType extends MyCommandBuilder> =
+  Parameters<BuilderType>[0];
+export type MyCommandModuleU<BuilderType extends MyCommandBuilder> = Exclude<
+  Awaited<ReturnType<BuilderType>>['argv'],
+  Promise<unknown>
+>;
+export type MyCommandModule<BuilderType extends MyCommandBuilder> =
+  CommandModule<MyCommandModuleT<BuilderType>, MyCommandModuleU<BuilderType>>;
 
-export type MyArgv<BuilderType extends MyCommandBuilder> = MyCommandModuleU<BuilderType>;
+export type MyArgv<BuilderType extends MyCommandBuilder> =
+  MyCommandModuleU<BuilderType>;
 
 export type MetaConstructorsCommandMeta = Omit<CommandMeta, 'packageManager'>;
-export type MetaConstructors<BuilderType extends MyCommandBuilder = MyCommandBuilder> = Record<PackageManager, (argv: MyCommandModuleU<BuilderType>) => MetaConstructorsCommandMeta>;
+export type MetaConstructors<
+  BuilderType extends MyCommandBuilder = MyCommandBuilder,
+> = Record<
+  PackageManager,
+  (argv: MyCommandModuleU<BuilderType>) => MetaConstructorsCommandMeta
+>;

--- a/src/commandHandler/types.ts
+++ b/src/commandHandler/types.ts
@@ -5,6 +5,7 @@ import type { PackageManager } from '../packageManager/packageManager';
 // eslint-disable-next-line @typescript-eslint/ban-types
 export type MyCommandBuilder<T = {}, U = {}> = Extract<
   CommandBuilder<T, U>,
+  // eslint-disable-next-line @typescript-eslint/ban-types
   Function
 >;
 export type MyCommandModuleT<BuilderType extends MyCommandBuilder> =

--- a/src/commands/_template.ts
+++ b/src/commands/_template.ts
@@ -1,5 +1,9 @@
-import { MetaConstructors, MetaConstructorsCommandMeta, MyCommandModule } from '../commandHandler/types';
-import { PackageManager } from "../packageManager/packageManager";
+import {
+  MetaConstructors,
+  MetaConstructorsCommandMeta,
+  MyCommandModule,
+} from '../commandHandler/types';
+import { PackageManager } from '../packageManager/packageManager';
 import { Argv } from 'yargs';
 import { createBaseCommandHandler } from '../commandHandler/createBaseCommandHandler';
 
@@ -17,40 +21,40 @@ const builder = (yargs: Argv) => {
 };
 
 const metaConstructors: MetaConstructors<typeof builder> = {
-  [PackageManager.NPM]: (argv) => {
+  [PackageManager.NPM]: argv => {
     const meta: MetaConstructorsCommandMeta = {
       positionals: [],
       options: [
         {
           name: 'option',
           value: argv.option,
-        }
+        },
       ],
     };
 
     return meta;
   },
-  [PackageManager.YARN]: (argv) => {
+  [PackageManager.YARN]: argv => {
     const meta: MetaConstructorsCommandMeta = {
       positionals: [],
       options: [
         {
           name: 'option',
           value: argv.option,
-        }
+        },
       ],
     };
 
     return meta;
   },
-  [PackageManager.PNPM]: (argv) => {
+  [PackageManager.PNPM]: argv => {
     const meta: MetaConstructorsCommandMeta = {
       positionals: [],
       options: [
         {
           name: 'option',
           value: argv.option,
-        }
+        },
       ],
     };
 

--- a/src/commands/audit.ts
+++ b/src/commands/audit.ts
@@ -1,5 +1,9 @@
-import { MetaConstructors, MyCommandModule, MetaConstructorsCommandMeta } from '../commandHandler/types';
-import { PackageManager } from "../packageManager/packageManager";
+import {
+  MetaConstructors,
+  MyCommandModule,
+  MetaConstructorsCommandMeta,
+} from '../commandHandler/types';
+import { PackageManager } from '../packageManager/packageManager';
 import { Argv } from 'yargs';
 import { NotSupportedError } from '../errors/NotSupportedError';
 import { createBaseCommandHandler } from '../commandHandler/createBaseCommandHandler';
@@ -8,27 +12,31 @@ const builder = (yargs: Argv) => {
   return yargs
     .option('production', {
       alias: ['prod', 'P'],
-      describe: 'Only audit dependencies from dependencies (skip devDependencies)',
+      describe:
+        'Only audit dependencies from dependencies (skip devDependencies)',
       type: 'boolean',
     })
     .option('development', {
       alias: ['dev', 'D'],
-      describe: 'Only audit dependencies from devDependencies (skip dependencies)',
+      describe:
+        'Only audit dependencies from devDependencies (skip dependencies)',
       type: 'boolean',
     })
     .option('fix', {
-      describe: 'Try to automatically fix vulnerabilities by updating/adding packages',
+      describe:
+        'Try to automatically fix vulnerabilities by updating/adding packages',
       type: 'boolean',
     })
     .option('audit-level', {
-      describe: 'Only print advisories with severity greater than or equal to severity',
+      describe:
+        'Only print advisories with severity greater than or equal to severity',
       type: 'string',
       choices: ['low', 'moderate', 'high', 'critical'],
     });
 };
 
 const metaConstructors: MetaConstructors<typeof builder> = {
-  [PackageManager.NPM]: (argv) => {
+  [PackageManager.NPM]: argv => {
     const meta: MetaConstructorsCommandMeta = {
       positionals: [
         {
@@ -53,19 +61,19 @@ const metaConstructors: MetaConstructors<typeof builder> = {
       meta.options.push({
         name: '--only',
         value: 'prod',
-      })
+      });
     }
 
     if (argv.development) {
       meta.options.push({
         name: '--only',
         value: 'dev',
-      })
+      });
     }
 
     return meta;
   },
-  [PackageManager.YARN]: (argv) => {
+  [PackageManager.YARN]: argv => {
     const meta: MetaConstructorsCommandMeta = {
       positionals: [
         {
@@ -90,16 +98,16 @@ const metaConstructors: MetaConstructors<typeof builder> = {
 
       if (argv.production) groups.push('dependencies');
       if (argv.development) groups.push('devDependencies');
-      
+
       meta.options.push({
         name: '--groups',
-        value: `"${groups.join(' ')}"`
-      })
+        value: `"${groups.join(' ')}"`,
+      });
     }
 
     return meta;
   },
-  [PackageManager.PNPM]: (argv) => {
+  [PackageManager.PNPM]: argv => {
     const meta: MetaConstructorsCommandMeta = {
       positionals: [
         {

--- a/src/commands/bin.ts
+++ b/src/commands/bin.ts
@@ -1,44 +1,47 @@
 import { NotSupportedError } from '../errors/NotSupportedError';
-import { MetaConstructors, MetaConstructorsCommandMeta, MyCommandModule } from '../commandHandler/types';
-import { PackageManager } from "../packageManager/packageManager";
+import {
+  MetaConstructors,
+  MetaConstructorsCommandMeta,
+  MyCommandModule,
+} from '../commandHandler/types';
+import { PackageManager } from '../packageManager/packageManager';
 import { Argv } from 'yargs';
 import { createBaseCommandHandler } from '../commandHandler/createBaseCommandHandler';
 
 const builder = (yargs: Argv) => {
-  return yargs
-    .option('global', {
-      alias: ['g'],
-      describe: 'Print the location of the globally installed executables.',
-      type: 'boolean',
-    });
+  return yargs.option('global', {
+    alias: ['g'],
+    describe: 'Print the location of the globally installed executables.',
+    type: 'boolean',
+  });
 };
 
 const metaConstructors: MetaConstructors<typeof builder> = {
-  [PackageManager.NPM]: (argv) => {
+  [PackageManager.NPM]: argv => {
     const meta: MetaConstructorsCommandMeta = {
       positionals: [
         {
           order: 1,
-          value: 'bin'
-        }
+          value: 'bin',
+        },
       ],
       options: [
         {
           name: '--global',
           value: argv.global,
-        }
+        },
       ],
     };
 
     return meta;
   },
-  [PackageManager.YARN]: (argv) => {
+  [PackageManager.YARN]: argv => {
     const meta: MetaConstructorsCommandMeta = {
       positionals: [
         {
           order: 1,
-          value: 'bin'
-        }
+          value: 'bin',
+        },
       ],
       options: [],
     };
@@ -49,19 +52,19 @@ const metaConstructors: MetaConstructors<typeof builder> = {
 
     return meta;
   },
-  [PackageManager.PNPM]: (argv) => {
+  [PackageManager.PNPM]: argv => {
     const meta: MetaConstructorsCommandMeta = {
       positionals: [
         {
           order: 1,
-          value: 'bin'
-        }
+          value: 'bin',
+        },
       ],
       options: [
         {
           name: '--global',
           value: argv.global,
-        }
+        },
       ],
     };
 
@@ -72,7 +75,8 @@ const metaConstructors: MetaConstructors<typeof builder> = {
 const commandModule: MyCommandModule<typeof builder> = {
   command: 'bin',
   aliases: [],
-  describe: 'Prints the directory into which the executables of dependencies are linked',
+  describe:
+    'Prints the directory into which the executables of dependencies are linked',
   // See README.md ## FAQ
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore

--- a/src/commands/bin.ts
+++ b/src/commands/bin.ts
@@ -77,7 +77,7 @@ const commandModule: MyCommandModule<typeof builder> = {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
   builder,
-  handler: createBaseCommandHandler(metaConstructors),
+  handler: createBaseCommandHandler.global(metaConstructors),
 };
 
 export default commandModule;

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -2,10 +2,10 @@ import { getConfig } from '../config/getConfig';
 import { UnpmConfig } from '../config/types';
 import { updateConfig } from '../config/updateConfig';
 import { MyCommandModule } from '../commandHandler/types';
-import { PackageManager } from "../packageManager/packageManager";
-import { isPackageManager } from "../packageManager/isPackageManager";
+import { PackageManager } from '../packageManager/packageManager';
+import { isPackageManager } from '../packageManager/isPackageManager';
 import { Argv } from 'yargs';
-import { setDefaultPackageManager } from "../config/setDefaultPackageManager";
+import { setDefaultPackageManager } from '../config/setDefaultPackageManager';
 import { setGlobalPackageManager } from '../config/setGlobalPackageManager';
 import { printText } from '../io/printText';
 
@@ -20,7 +20,7 @@ const builder = (yargs: Argv) => {
     .positional('value', {
       describe: 'Value to set',
       type: 'string',
-    })
+    });
 };
 
 async function printConfigProperty(key: keyof UnpmConfig) {
@@ -34,12 +34,13 @@ async function printConfigProperty(key: keyof UnpmConfig) {
 const commandModule: MyCommandModule<typeof builder> = {
   command: 'config <name> [value]',
   aliases: ['c'],
-  describe: 'Manage the configuration (unpm config, not the config of package managers), config file located at "~/.unpmrc"',
+  describe:
+    'Manage the configuration (unpm config, not the config of package managers), config file located at "~/.unpmrc"',
   // See README.md ## FAQ
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
   builder,
-  handler: async (argv) => {
+  handler: async argv => {
     // Evil hack, but it is fine, because we validate this argument before it reaches this place
     const name = argv.name as keyof UnpmConfig;
 
@@ -53,7 +54,11 @@ const commandModule: MyCommandModule<typeof builder> = {
       const value = isPackageManager(argv.value);
 
       if (!value) {
-        throw new Error(`"defaultPm" option must be one of [${Object.values(PackageManager).join(', ')}]`);
+        throw new Error(
+          `"defaultPm" option must be one of [${Object.values(
+            PackageManager,
+          ).join(', ')}]`,
+        );
       }
 
       await setDefaultPackageManager(value);
@@ -61,7 +66,12 @@ const commandModule: MyCommandModule<typeof builder> = {
       const value = isPackageManager(argv.value);
 
       if (argv.value !== 'null' && !value) {
-        throw new Error(`"defaultPm" option must be one of [${[...Object.values(PackageManager), 'null'].join(', ')}]`);
+        throw new Error(
+          `"defaultPm" option must be one of [${[
+            ...Object.values(PackageManager),
+            'null',
+          ].join(', ')}]`,
+        );
       }
 
       await setGlobalPackageManager(value);

--- a/src/commands/exec.ts
+++ b/src/commands/exec.ts
@@ -1,5 +1,9 @@
-import { MetaConstructors, MetaConstructorsCommandMeta, MyCommandModule } from '../commandHandler/types';
-import { PackageManager } from "../packageManager/packageManager";
+import {
+  MetaConstructors,
+  MetaConstructorsCommandMeta,
+  MyCommandModule,
+} from '../commandHandler/types';
+import { PackageManager } from '../packageManager/packageManager';
 import { Argv } from 'yargs';
 import { createBaseCommandHandler } from '../commandHandler/createBaseCommandHandler';
 
@@ -10,8 +14,8 @@ const builder = (yargs: Argv) => {
 };
 
 const metaConstructors: MetaConstructors<typeof builder> = {
-  [PackageManager.NPM]: (argv) => {
-    const args =  argv._.slice(1).map((arg, i) => ({
+  [PackageManager.NPM]: argv => {
+    const args = argv._.slice(1).map((arg, i) => ({
       order: i + 3,
       value: arg.toString(),
     }));
@@ -20,7 +24,7 @@ const metaConstructors: MetaConstructors<typeof builder> = {
       positionals: [
         {
           order: 1,
-          value: 'exec'
+          value: 'exec',
         },
         {
           order: 2,
@@ -34,12 +38,12 @@ const metaConstructors: MetaConstructors<typeof builder> = {
 
     return meta;
   },
-  [PackageManager.YARN]: (argv) => {
+  [PackageManager.YARN]: argv => {
     const meta: MetaConstructorsCommandMeta = {
       positionals: [
         {
           order: 1,
-          value: 'run'
+          value: 'run',
         },
         ...argv._.slice(1).map((arg, i) => ({
           order: i + 2,
@@ -51,12 +55,12 @@ const metaConstructors: MetaConstructors<typeof builder> = {
 
     return meta;
   },
-  [PackageManager.PNPM]: (argv) => {
+  [PackageManager.PNPM]: argv => {
     const meta: MetaConstructorsCommandMeta = {
       positionals: [
         {
           order: 1,
-          value: 'exec'
+          value: 'exec',
         },
         ...argv._.slice(1).map((arg, i) => ({
           order: i + 2,

--- a/src/commands/exec.ts
+++ b/src/commands/exec.ts
@@ -4,7 +4,9 @@ import { Argv } from 'yargs';
 import { createBaseCommandHandler } from '../commandHandler/createBaseCommandHandler';
 
 const builder = (yargs: Argv) => {
-  return yargs;
+  return yargs
+    .example('$0 exec nodemon', 'Run nodemon')
+    .example('$0 exec tsc --watch', 'Run typescript compiler in watch mode');
 };
 
 const metaConstructors: MetaConstructors<typeof builder> = {

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,5 +1,9 @@
-import { MetaConstructors, MetaConstructorsCommandMeta, MyCommandModule } from '../commandHandler/types';
-import { PackageManager } from "../packageManager/packageManager";
+import {
+  MetaConstructors,
+  MetaConstructorsCommandMeta,
+  MyCommandModule,
+} from '../commandHandler/types';
+import { PackageManager } from '../packageManager/packageManager';
 import { Argv } from 'yargs';
 import { createBaseCommandHandler } from '../commandHandler/createBaseCommandHandler';
 
@@ -14,7 +18,7 @@ const metaConstructors: MetaConstructors<typeof builder> = {
         {
           order: 1,
           value: 'init',
-        }
+        },
       ],
       options: [],
     };
@@ -27,7 +31,7 @@ const metaConstructors: MetaConstructors<typeof builder> = {
         {
           order: 1,
           value: 'init',
-        }
+        },
       ],
       options: [],
     };
@@ -40,7 +44,7 @@ const metaConstructors: MetaConstructors<typeof builder> = {
         {
           order: 1,
           value: 'init',
-        }
+        },
       ],
       options: [],
     };

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -1,5 +1,9 @@
-import { MetaConstructors, MetaConstructorsCommandMeta, MyCommandModule } from '../commandHandler/types';
-import { PackageManager } from "../packageManager/packageManager";
+import {
+  MetaConstructors,
+  MetaConstructorsCommandMeta,
+  MyCommandModule,
+} from '../commandHandler/types';
+import { PackageManager } from '../packageManager/packageManager';
 import { Argv } from 'yargs';
 import { createBaseCommandHandler } from '../commandHandler/createBaseCommandHandler';
 
@@ -22,7 +26,8 @@ const builder = (args: Argv) => {
     })
     .option('save-exact', {
       alias: ['E', 'exact'],
-      describe: 'Saved dependencies will be configured with an exact version rather than using default semver range operator',
+      describe:
+        'Saved dependencies will be configured with an exact version rather than using default semver range operator',
       type: 'boolean',
     })
     .option('save-optional', {
@@ -43,7 +48,7 @@ const builder = (args: Argv) => {
 };
 
 const metaConstructors: MetaConstructors<typeof builder> = {
-  [PackageManager.NPM]: (argv) => {
+  [PackageManager.NPM]: argv => {
     const meta: MetaConstructorsCommandMeta = {
       positionals: [
         {
@@ -53,7 +58,7 @@ const metaConstructors: MetaConstructors<typeof builder> = {
         {
           order: 2,
           value: argv.packages,
-        }
+        },
       ],
       options: [
         {
@@ -79,19 +84,19 @@ const metaConstructors: MetaConstructors<typeof builder> = {
         {
           name: '--global',
           value: argv.global,
-        }
+        },
       ],
     };
 
     return meta;
   },
-  [PackageManager.YARN]: (argv) => {
+  [PackageManager.YARN]: argv => {
     const meta: MetaConstructorsCommandMeta = {
       positionals: [
         {
           order: 0,
           value: 'global',
-          condition: !!argv.global
+          condition: !!argv.global,
         },
         {
           order: 1,
@@ -100,7 +105,7 @@ const metaConstructors: MetaConstructors<typeof builder> = {
         {
           order: 2,
           value: argv.packages,
-        }
+        },
       ],
       options: [
         {
@@ -128,7 +133,7 @@ const metaConstructors: MetaConstructors<typeof builder> = {
 
     return meta;
   },
-  [PackageManager.PNPM]: (argv) => {
+  [PackageManager.PNPM]: argv => {
     const meta: MetaConstructorsCommandMeta = {
       positionals: [
         {
@@ -138,7 +143,7 @@ const metaConstructors: MetaConstructors<typeof builder> = {
         {
           order: 2,
           value: argv.packages,
-        }
+        },
       ],
       options: [
         {
@@ -164,7 +169,7 @@ const metaConstructors: MetaConstructors<typeof builder> = {
         {
           name: '--global',
           value: argv.global,
-        }
+        },
       ],
     };
 

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -180,7 +180,7 @@ const commandModule: MyCommandModule<typeof builder> = {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
   builder,
-  handler: createBaseCommandHandler(metaConstructors),
+  handler: createBaseCommandHandler.global(metaConstructors),
 };
 
 export default commandModule;

--- a/src/commands/licenses.ts
+++ b/src/commands/licenses.ts
@@ -30,7 +30,7 @@ const metaConstructors: MetaConstructors<typeof builder> = {
       positionals: [
         {
           order: 1,
-          value: 'licenses',
+          value: 'licenses list',
         },
       ],
       options: [],

--- a/src/commands/licenses.ts
+++ b/src/commands/licenses.ts
@@ -1,5 +1,9 @@
-import { MetaConstructors, MetaConstructorsCommandMeta, MyCommandModule } from '../commandHandler/types';
-import { PackageManager } from "../packageManager/packageManager";
+import {
+  MetaConstructors,
+  MetaConstructorsCommandMeta,
+  MyCommandModule,
+} from '../commandHandler/types';
+import { PackageManager } from '../packageManager/packageManager';
 import { Argv } from 'yargs';
 import { NotSupportedError } from '../errors/NotSupportedError';
 import { createBaseCommandHandler } from '../commandHandler/createBaseCommandHandler';
@@ -39,7 +43,6 @@ const metaConstructors: MetaConstructors<typeof builder> = {
     return meta;
   },
 };
-
 
 const commandModule: MyCommandModule<typeof builder> = {
   command: 'licenses',

--- a/src/commands/link.ts
+++ b/src/commands/link.ts
@@ -1,18 +1,21 @@
-import { MetaConstructors, MetaConstructorsCommandMeta, MyCommandModule } from '../commandHandler/types';
-import { PackageManager } from "../packageManager/packageManager";
+import {
+  MetaConstructors,
+  MetaConstructorsCommandMeta,
+  MyCommandModule,
+} from '../commandHandler/types';
+import { PackageManager } from '../packageManager/packageManager';
 import { Argv } from 'yargs';
 import { createBaseCommandHandler } from '../commandHandler/createBaseCommandHandler';
 
 const builder = (yargs: Argv) => {
-  return yargs
-    .positional('package', {
-      describe: 'The package to link',
-      type: 'string',
-    });
+  return yargs.positional('package', {
+    describe: 'The package to link',
+    type: 'string',
+  });
 };
 
 const metaConstructors: MetaConstructors<typeof builder> = {
-  [PackageManager.NPM]: (argv) => {
+  [PackageManager.NPM]: argv => {
     const meta: MetaConstructorsCommandMeta = {
       positionals: [
         {
@@ -29,7 +32,7 @@ const metaConstructors: MetaConstructors<typeof builder> = {
 
     return meta;
   },
-  [PackageManager.YARN]: (argv) => {
+  [PackageManager.YARN]: argv => {
     const meta: MetaConstructorsCommandMeta = {
       positionals: [
         {
@@ -46,7 +49,7 @@ const metaConstructors: MetaConstructors<typeof builder> = {
 
     return meta;
   },
-  [PackageManager.PNPM]: (argv) => {
+  [PackageManager.PNPM]: argv => {
     const meta: MetaConstructorsCommandMeta = {
       positionals: [
         {

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -111,7 +111,7 @@ const commandModule: MyCommandModule<typeof builder> = {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
   builder,
-  handler: createBaseCommandHandler(metaConstructors),
+  handler: createBaseCommandHandler.global(metaConstructors),
 };
 
 export default commandModule;

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -1,5 +1,9 @@
-import { MetaConstructors, MetaConstructorsCommandMeta, MyCommandModule } from '../commandHandler/types';
-import { PackageManager } from "../packageManager/packageManager";
+import {
+  MetaConstructors,
+  MetaConstructorsCommandMeta,
+  MyCommandModule,
+} from '../commandHandler/types';
+import { PackageManager } from '../packageManager/packageManager';
 import { Argv } from 'yargs';
 import { createBaseCommandHandler } from '../commandHandler/createBaseCommandHandler';
 
@@ -18,11 +22,11 @@ const builder = (yargs: Argv) => {
       alias: 'd',
       describe: 'Max display depth of the dependency tree',
       type: 'number',
-    })
+    });
 };
 
 const metaConstructors: MetaConstructors<typeof builder> = {
-  [PackageManager.NPM]: (argv) => {
+  [PackageManager.NPM]: argv => {
     const meta: MetaConstructorsCommandMeta = {
       positionals: [
         {
@@ -48,7 +52,7 @@ const metaConstructors: MetaConstructors<typeof builder> = {
 
     return meta;
   },
-  [PackageManager.YARN]: (argv) => {
+  [PackageManager.YARN]: argv => {
     const meta: MetaConstructorsCommandMeta = {
       positionals: [
         {
@@ -69,13 +73,13 @@ const metaConstructors: MetaConstructors<typeof builder> = {
         {
           name: '--pattern',
           value: argv.name,
-        }
+        },
       ],
     };
 
     return meta;
   },
-  [PackageManager.PNPM]: (argv) => {
+  [PackageManager.PNPM]: argv => {
     const meta: MetaConstructorsCommandMeta = {
       positionals: [
         {

--- a/src/commands/outdated.ts
+++ b/src/commands/outdated.ts
@@ -94,7 +94,7 @@ const commandModule: MyCommandModule<typeof builder> = {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
   builder,
-  handler: createBaseCommandHandler(metaConstructors),
+  handler: createBaseCommandHandler.global(metaConstructors),
 };
 
 export default commandModule;

--- a/src/commands/outdated.ts
+++ b/src/commands/outdated.ts
@@ -1,6 +1,10 @@
 import { NotSupportedError } from '../errors/NotSupportedError';
-import { MyCommandModule, MetaConstructors, MetaConstructorsCommandMeta } from '../commandHandler/types';
-import { PackageManager } from "../packageManager/packageManager";
+import {
+  MyCommandModule,
+  MetaConstructors,
+  MetaConstructorsCommandMeta,
+} from '../commandHandler/types';
+import { PackageManager } from '../packageManager/packageManager';
 import { Argv } from 'yargs';
 import { createBaseCommandHandler } from '../commandHandler/createBaseCommandHandler';
 
@@ -19,7 +23,7 @@ const builder = (yargs: Argv) => {
 };
 
 const metaConstructors: MetaConstructors<typeof builder> = {
-  [PackageManager.NPM]: (argv) => {
+  [PackageManager.NPM]: argv => {
     const meta: MetaConstructorsCommandMeta = {
       positionals: [
         {
@@ -41,7 +45,7 @@ const metaConstructors: MetaConstructors<typeof builder> = {
 
     return meta;
   },
-  [PackageManager.YARN]: (argv) => {
+  [PackageManager.YARN]: argv => {
     const meta: MetaConstructorsCommandMeta = {
       positionals: [
         {
@@ -62,7 +66,7 @@ const metaConstructors: MetaConstructors<typeof builder> = {
 
     return meta;
   },
-  [PackageManager.PNPM]: (argv) => {
+  [PackageManager.PNPM]: argv => {
     const meta: MetaConstructorsCommandMeta = {
       positionals: [
         {

--- a/src/commands/pack.ts
+++ b/src/commands/pack.ts
@@ -1,21 +1,23 @@
 import { NotSupportedError } from '../errors/NotSupportedError';
-import { MetaConstructors, MetaConstructorsCommandMeta, MyCommandModule } from '../commandHandler/types';
-import { PackageManager } from "../packageManager/packageManager";
+import {
+  MetaConstructors,
+  MetaConstructorsCommandMeta,
+  MyCommandModule,
+} from '../commandHandler/types';
+import { PackageManager } from '../packageManager/packageManager';
 import { Argv } from 'yargs';
 import { createBaseCommandHandler } from '../commandHandler/createBaseCommandHandler';
 
 const builder = (yargs: Argv) => {
-  return yargs
-    .option('pack-destination', {
-      alias: ['dir', 'd'],
-      describe: 'Output directory for the tarball',
-      type: 'string',
-    });
+  return yargs.option('pack-destination', {
+    alias: ['dir', 'd'],
+    describe: 'Output directory for the tarball',
+    type: 'string',
+  });
 };
 
-
 const metaConstructors: MetaConstructors<typeof builder> = {
-  [PackageManager.NPM]: (argv) => {
+  [PackageManager.NPM]: argv => {
     const meta: MetaConstructorsCommandMeta = {
       positionals: [
         {
@@ -33,7 +35,7 @@ const metaConstructors: MetaConstructors<typeof builder> = {
 
     return meta;
   },
-  [PackageManager.YARN]: (argv) => {
+  [PackageManager.YARN]: argv => {
     const meta: MetaConstructorsCommandMeta = {
       positionals: [
         {
@@ -45,12 +47,15 @@ const metaConstructors: MetaConstructors<typeof builder> = {
     };
 
     if (argv.packDestination) {
-      throw new NotSupportedError('pack --pack-destination <dir>', PackageManager.YARN);
+      throw new NotSupportedError(
+        'pack --pack-destination <dir>',
+        PackageManager.YARN,
+      );
     }
 
     return meta;
   },
-  [PackageManager.PNPM]: (argv) => {
+  [PackageManager.PNPM]: argv => {
     const meta: MetaConstructorsCommandMeta = {
       positionals: [
         {

--- a/src/commands/rebuild.ts
+++ b/src/commands/rebuild.ts
@@ -1,6 +1,10 @@
 import { NotSupportedError } from '../errors/NotSupportedError';
-import { MetaConstructors, MetaConstructorsCommandMeta, MyCommandModule } from '../commandHandler/types';
-import { PackageManager } from "../packageManager/packageManager";
+import {
+  MetaConstructors,
+  MetaConstructorsCommandMeta,
+  MyCommandModule,
+} from '../commandHandler/types';
+import { PackageManager } from '../packageManager/packageManager';
 import { Argv } from 'yargs';
 import { createBaseCommandHandler } from '../commandHandler/createBaseCommandHandler';
 
@@ -13,7 +17,7 @@ const builder = (yargs: Argv) => {
 };
 
 const metaConstructors: MetaConstructors<typeof builder> = {
-  [PackageManager.NPM]: (argv) => {
+  [PackageManager.NPM]: argv => {
     const meta: MetaConstructorsCommandMeta = {
       positionals: [
         {
@@ -33,7 +37,7 @@ const metaConstructors: MetaConstructors<typeof builder> = {
   [PackageManager.YARN]: () => {
     throw new NotSupportedError('rebuild', PackageManager.YARN);
   },
-  [PackageManager.PNPM]: (argv) => {
+  [PackageManager.PNPM]: argv => {
     const meta: MetaConstructorsCommandMeta = {
       positionals: [
         {

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -1,12 +1,20 @@
-import { MetaConstructors, MetaConstructorsCommandMeta, MyCommandModule, MyArgv } from '../commandHandler/types';
-import { PackageManager } from "../packageManager/packageManager";
+import {
+  MetaConstructors,
+  MetaConstructorsCommandMeta,
+  MyCommandModule,
+  MyArgv,
+} from '../commandHandler/types';
+import { PackageManager } from '../packageManager/packageManager';
 import { Argv } from 'yargs';
 import { createBaseCommandHandler } from '../commandHandler/createBaseCommandHandler';
 
 const builder = (yargs: Argv) => {
   return yargs
     .example('$0 test', 'Run "test" script')
-    .example('$0 create-command <command-name>', 'Run "create-command" script and pass <command-name> as an argument to it')
+    .example(
+      '$0 create-command <command-name>',
+      'Run "create-command" script and pass <command-name> as an argument to it',
+    )
     .example('$0 run typecheck --watch', 'Run typecheck in watch mode')
     .positional('script', {
       describe: 'The name of the script to run',
@@ -19,23 +27,25 @@ const shouldFallbackToInstall = (argv: MyArgv<typeof builder>) => {
 };
 
 const metaConstructors: MetaConstructors<typeof builder> = {
-  [PackageManager.NPM]: (argv) => {
+  [PackageManager.NPM]: argv => {
     if (shouldFallbackToInstall(argv)) {
       return {
         positionals: [
           {
             order: 1,
-            value: 'install'
-          }
+            value: 'install',
+          },
         ],
         options: [],
-      }
+      };
     }
 
-    const args =  argv._.filter(v => !v.toString().match(/run(-script)?/)).map((arg, i) => ({
-      order: i + 4,
-      value: arg.toString(),
-    }));
+    const args = argv._.filter(v => !v.toString().match(/run(-script)?/)).map(
+      (arg, i) => ({
+        order: i + 4,
+        value: arg.toString(),
+      }),
+    );
 
     const meta: MetaConstructorsCommandMeta = {
       positionals: [
@@ -59,17 +69,17 @@ const metaConstructors: MetaConstructors<typeof builder> = {
 
     return meta;
   },
-  [PackageManager.YARN]: (argv) => {
+  [PackageManager.YARN]: argv => {
     if (shouldFallbackToInstall(argv)) {
       return {
         positionals: [
           {
             order: 1,
-            value: 'install'
-          }
+            value: 'install',
+          },
         ],
         options: [],
-      }
+      };
     }
 
     const meta: MetaConstructorsCommandMeta = {
@@ -82,27 +92,29 @@ const metaConstructors: MetaConstructors<typeof builder> = {
           order: 2,
           value: argv.script,
         },
-        ...argv._.filter(v => !v.toString().match(/run(-script)?/)).map((arg, i) => ({
-          order: i + 3,
-          value: arg.toString(),
-        })),
+        ...argv._.filter(v => !v.toString().match(/run(-script)?/)).map(
+          (arg, i) => ({
+            order: i + 3,
+            value: arg.toString(),
+          }),
+        ),
       ],
       options: [],
     };
 
     return meta;
   },
-  [PackageManager.PNPM]: (argv) => {
+  [PackageManager.PNPM]: argv => {
     if (shouldFallbackToInstall(argv)) {
       return {
         positionals: [
           {
             order: 1,
-            value: 'install'
-          }
+            value: 'install',
+          },
         ],
         options: [],
-      }
+      };
     }
 
     const meta: MetaConstructorsCommandMeta = {
@@ -115,10 +127,12 @@ const metaConstructors: MetaConstructors<typeof builder> = {
           order: 2,
           value: argv.script,
         },
-        ...argv._.filter(v => !v.toString().match(/run(-script)?/)).map((arg, i) => ({
-          order: i + 3,
-          value: arg.toString(),
-        })),
+        ...argv._.filter(v => !v.toString().match(/run(-script)?/)).map(
+          (arg, i) => ({
+            order: i + 3,
+            value: arg.toString(),
+          }),
+        ),
       ],
       options: [],
     };
@@ -126,7 +140,6 @@ const metaConstructors: MetaConstructors<typeof builder> = {
     return meta;
   },
 };
-
 
 const commandModule: MyCommandModule<typeof builder> = {
   command: 'run [script]',

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -5,10 +5,13 @@ import { createBaseCommandHandler } from '../commandHandler/createBaseCommandHan
 
 const builder = (yargs: Argv) => {
   return yargs
+    .example('$0 test', 'Run "test" script')
+    .example('$0 create-command <command-name>', 'Run "create-command" script and pass <command-name> as an argument to it')
+    .example('$0 run typecheck --watch', 'Run typecheck in watch mode')
     .positional('script', {
       describe: 'The name of the script to run',
       type: 'string',
-    })
+    });
 };
 
 const shouldFallbackToInstall = (argv: MyArgv<typeof builder>) => {

--- a/src/commands/uninstall.ts
+++ b/src/commands/uninstall.ts
@@ -1,5 +1,9 @@
-import { MetaConstructors, MetaConstructorsCommandMeta, MyCommandModule } from '../commandHandler/types';
-import { PackageManager } from "../packageManager/packageManager";
+import {
+  MetaConstructors,
+  MetaConstructorsCommandMeta,
+  MyCommandModule,
+} from '../commandHandler/types';
+import { PackageManager } from '../packageManager/packageManager';
 import { Argv } from 'yargs';
 import { createBaseCommandHandler } from '../commandHandler/createBaseCommandHandler';
 
@@ -19,7 +23,7 @@ const builder = (yargs: Argv) => {
 };
 
 const metaConstructors: MetaConstructors<typeof builder> = {
-  [PackageManager.NPM]: (argv) => {
+  [PackageManager.NPM]: argv => {
     const meta: MetaConstructorsCommandMeta = {
       positionals: [
         {
@@ -29,7 +33,7 @@ const metaConstructors: MetaConstructors<typeof builder> = {
         {
           order: 2,
           value: argv.packages,
-        }
+        },
       ],
       options: [
         {
@@ -41,7 +45,7 @@ const metaConstructors: MetaConstructors<typeof builder> = {
 
     return meta;
   },
-  [PackageManager.YARN]: (argv) => {
+  [PackageManager.YARN]: argv => {
     const meta: MetaConstructorsCommandMeta = {
       positionals: [
         {
@@ -56,14 +60,14 @@ const metaConstructors: MetaConstructors<typeof builder> = {
         {
           order: 2,
           value: argv.packages,
-        }
+        },
       ],
       options: [],
     };
 
     return meta;
   },
-  [PackageManager.PNPM]: (argv) => {
+  [PackageManager.PNPM]: argv => {
     const meta: MetaConstructorsCommandMeta = {
       positionals: [
         {
@@ -73,7 +77,7 @@ const metaConstructors: MetaConstructors<typeof builder> = {
         {
           order: 2,
           value: argv.packages,
-        }
+        },
       ],
       options: [
         {
@@ -86,7 +90,6 @@ const metaConstructors: MetaConstructors<typeof builder> = {
     return meta;
   },
 };
-
 
 const commandModule: MyCommandModule<typeof builder> = {
   command: 'uninstall <packages..>',

--- a/src/commands/uninstall.ts
+++ b/src/commands/uninstall.ts
@@ -96,7 +96,7 @@ const commandModule: MyCommandModule<typeof builder> = {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
   builder,
-  handler: createBaseCommandHandler(metaConstructors),
+  handler: createBaseCommandHandler.global(metaConstructors),
 };
 
 export default commandModule;

--- a/src/commands/unlink.ts
+++ b/src/commands/unlink.ts
@@ -1,18 +1,21 @@
-import { MetaConstructors, MetaConstructorsCommandMeta, MyCommandModule } from '../commandHandler/types';
-import { PackageManager } from "../packageManager/packageManager";
+import {
+  MetaConstructors,
+  MetaConstructorsCommandMeta,
+  MyCommandModule,
+} from '../commandHandler/types';
+import { PackageManager } from '../packageManager/packageManager';
 import { Argv } from 'yargs';
 import { createBaseCommandHandler } from '../commandHandler/createBaseCommandHandler';
 
 const builder = (yargs: Argv) => {
-  return yargs
-    .positional('package', {
-      describe: 'The package to unlink',
-      type: 'string',
-    });
+  return yargs.positional('package', {
+    describe: 'The package to unlink',
+    type: 'string',
+  });
 };
 
 const metaConstructors: MetaConstructors<typeof builder> = {
-  [PackageManager.NPM]: (argv) => {
+  [PackageManager.NPM]: argv => {
     const meta: MetaConstructorsCommandMeta = {
       positionals: [
         {
@@ -29,7 +32,7 @@ const metaConstructors: MetaConstructors<typeof builder> = {
 
     return meta;
   },
-  [PackageManager.YARN]: (argv) => {
+  [PackageManager.YARN]: argv => {
     const meta: MetaConstructorsCommandMeta = {
       positionals: [
         {
@@ -46,7 +49,7 @@ const metaConstructors: MetaConstructors<typeof builder> = {
 
     return meta;
   },
-  [PackageManager.PNPM]: (argv) => {
+  [PackageManager.PNPM]: argv => {
     const meta: MetaConstructorsCommandMeta = {
       positionals: [
         {

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -114,7 +114,7 @@ const commandModule: MyCommandModule<typeof builder> = {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
   builder,
-  handler: createBaseCommandHandler(metaConstructors),
+  handler: createBaseCommandHandler.global(metaConstructors),
 };
 
 export default commandModule;

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -1,5 +1,9 @@
-import { MetaConstructors, MetaConstructorsCommandMeta, MyCommandModule } from '../commandHandler/types';
-import { PackageManager } from "../packageManager/packageManager";
+import {
+  MetaConstructors,
+  MetaConstructorsCommandMeta,
+  MyCommandModule,
+} from '../commandHandler/types';
+import { PackageManager } from '../packageManager/packageManager';
 import { Argv } from 'yargs';
 import { createBaseCommandHandler } from '../commandHandler/createBaseCommandHandler';
 
@@ -22,9 +26,8 @@ const builder = (yargs: Argv) => {
     });
 };
 
-
 const metaConstructors: MetaConstructors<typeof builder> = {
-  [PackageManager.NPM]: (argv) => {
+  [PackageManager.NPM]: argv => {
     const meta: MetaConstructorsCommandMeta = {
       positionals: [
         {
@@ -50,7 +53,7 @@ const metaConstructors: MetaConstructors<typeof builder> = {
 
     return meta;
   },
-  [PackageManager.YARN]: (argv) => {
+  [PackageManager.YARN]: argv => {
     const meta: MetaConstructorsCommandMeta = {
       positionals: [
         {
@@ -79,7 +82,7 @@ const metaConstructors: MetaConstructors<typeof builder> = {
 
     return meta;
   },
-  [PackageManager.PNPM]: (argv) => {
+  [PackageManager.PNPM]: argv => {
     const meta: MetaConstructorsCommandMeta = {
       positionals: [
         {

--- a/src/commands/version.ts
+++ b/src/commands/version.ts
@@ -1,5 +1,9 @@
-import { MetaConstructors, MetaConstructorsCommandMeta, MyCommandModule } from '../commandHandler/types';
-import { PackageManager } from "../packageManager/packageManager";
+import {
+  MetaConstructors,
+  MetaConstructorsCommandMeta,
+  MyCommandModule,
+} from '../commandHandler/types';
+import { PackageManager } from '../packageManager/packageManager';
 import { Argv } from 'yargs';
 import { createBaseCommandHandler } from '../commandHandler/createBaseCommandHandler';
 
@@ -10,13 +14,15 @@ const versionOptionYarnMapping: Record<string, string> = {
   premajor: '--premajor',
   preminor: '--preminor',
   prepatch: '--prepatch',
-  prerelease: '--prerelease'
-}
+  prerelease: '--prerelease',
+};
 
 const builder = (yargs: Argv) => {
   return yargs
     .positional('newversion', {
-      describe: `The new version to set [<newversion> | ${Object.keys(versionOptionYarnMapping).join(' | ')}]`,
+      describe: `The new version to set [<newversion> | ${Object.keys(
+        versionOptionYarnMapping,
+      ).join(' | ')}]`,
       type: 'string',
     })
     .option('commit-hooks', {
@@ -27,35 +33,35 @@ const builder = (yargs: Argv) => {
 };
 
 const metaConstructors: MetaConstructors<typeof builder> = {
-  [PackageManager.NPM]: (argv) => {
+  [PackageManager.NPM]: argv => {
     const meta: MetaConstructorsCommandMeta = {
       positionals: [
         {
           order: 1,
-          value: 'version'
+          value: 'version',
         },
         {
           order: 2,
           value: argv.newversion,
-        }
+        },
       ],
       options: [
         {
           name: '--commit-hooks',
           value: argv.commitHooks === false ? 'false' : undefined,
-        }
+        },
       ],
     };
 
     return meta;
   },
-  [PackageManager.YARN]: (argv) => {
+  [PackageManager.YARN]: argv => {
     const meta: MetaConstructorsCommandMeta = {
       positionals: [
         {
           order: 1,
-          value: 'version'
-        }
+          value: 'version',
+        },
       ],
       options: [],
     };
@@ -76,7 +82,7 @@ const metaConstructors: MetaConstructors<typeof builder> = {
 
     return meta;
   },
-  [PackageManager.PNPM]: (argv) => {
+  [PackageManager.PNPM]: argv => {
     return metaConstructors[PackageManager.NPM](argv);
   },
 };

--- a/src/commands/why.ts
+++ b/src/commands/why.ts
@@ -1,19 +1,22 @@
-import { MetaConstructors, MetaConstructorsCommandMeta, MyCommandModule } from '../commandHandler/types';
-import { PackageManager } from "../packageManager/packageManager";
+import {
+  MetaConstructors,
+  MetaConstructorsCommandMeta,
+  MyCommandModule,
+} from '../commandHandler/types';
+import { PackageManager } from '../packageManager/packageManager';
 import { Argv } from 'yargs';
 import { createBaseCommandHandler } from '../commandHandler/createBaseCommandHandler';
 
 const builder = (yargs: Argv) => {
-  return yargs
-    .positional('dependency', {
-      describe: 'Dependency to explain',
-      type: 'string',
-      demandOption: true,
-    });
+  return yargs.positional('dependency', {
+    describe: 'Dependency to explain',
+    type: 'string',
+    demandOption: true,
+  });
 };
 
 const metaConstructors: MetaConstructors<typeof builder> = {
-  [PackageManager.NPM]: (argv) => {
+  [PackageManager.NPM]: argv => {
     const meta: MetaConstructorsCommandMeta = {
       positionals: [
         {
@@ -30,7 +33,7 @@ const metaConstructors: MetaConstructors<typeof builder> = {
 
     return meta;
   },
-  [PackageManager.YARN]: (argv) => {
+  [PackageManager.YARN]: argv => {
     const meta: MetaConstructorsCommandMeta = {
       positionals: [
         {
@@ -47,7 +50,7 @@ const metaConstructors: MetaConstructors<typeof builder> = {
 
     return meta;
   },
-  [PackageManager.PNPM]: (argv) => {
+  [PackageManager.PNPM]: argv => {
     const meta: MetaConstructorsCommandMeta = {
       positionals: [
         {
@@ -65,7 +68,6 @@ const metaConstructors: MetaConstructors<typeof builder> = {
     return meta;
   },
 };
-
 
 const commandModule: MyCommandModule<typeof builder> = {
   command: 'why <dependency>',

--- a/src/config/getConfig.test.ts
+++ b/src/config/getConfig.test.ts
@@ -7,12 +7,14 @@ import { UnpmConfig } from './types';
 jest.mock('./internal/createConfigFileIfNotExists');
 jest.mock('./internal/readConfigFile');
 
-const createConfigFileIfNotExistsMock = jest.mocked(createConfigFileIfNotExists);
+const createConfigFileIfNotExistsMock = jest.mocked(
+  createConfigFileIfNotExists,
+);
 const readConfigFileMock = jest.mocked(readConfigFile);
 
 describe('config/getConfig', () => {
   const mockConfig: UnpmConfig = {
-    ...defaultConfig
+    ...defaultConfig,
   };
 
   afterEach(() => {

--- a/src/config/getConfig.ts
+++ b/src/config/getConfig.ts
@@ -3,5 +3,5 @@ import { readConfigFile } from './internal/readConfigFile';
 import { UnpmConfig } from './types';
 
 export async function getConfig(): Promise<UnpmConfig> {
-  return await createConfigFileIfNotExists() ?? await readConfigFile();
+  return (await createConfigFileIfNotExists()) ?? (await readConfigFile());
 }

--- a/src/config/getDefaultPackageManager.test.ts
+++ b/src/config/getDefaultPackageManager.test.ts
@@ -1,6 +1,6 @@
 import { getDefaultPackageManager } from './getDefaultPackageManager';
 import { getConfig } from './getConfig';
-import { PackageManager } from "../packageManager/packageManager";
+import { PackageManager } from '../packageManager/packageManager';
 import { UnpmConfig } from './types';
 
 jest.mock('./getConfig');

--- a/src/config/getDefaultPackageManager.test.ts
+++ b/src/config/getDefaultPackageManager.test.ts
@@ -13,9 +13,9 @@ describe('config/getDefaultPackageManager', () => {
   });
 
   it('should return PackageManager.NPM if defaultPm is "npm"', async () => {
-    const mockConfig: UnpmConfig = {
+    const mockConfig = {
       defaultPm: 'npm',
-    };
+    } as unknown as UnpmConfig;
 
     getConfigMock.mockResolvedValue(mockConfig);
 
@@ -26,9 +26,9 @@ describe('config/getDefaultPackageManager', () => {
   });
 
   it('should return PackageManager.YARN if defaultPm is "yarn"', async () => {
-    const mockConfig: UnpmConfig = {
+    const mockConfig = {
       defaultPm: 'yarn',
-    };
+    } as unknown as UnpmConfig;
     getConfigMock.mockResolvedValue(mockConfig);
 
     const result = await getDefaultPackageManager();
@@ -38,9 +38,9 @@ describe('config/getDefaultPackageManager', () => {
   });
 
   it('should return PackageManager.PNPM if defaultPm is "pnpm"', async () => {
-    const mockConfig: UnpmConfig = {
+    const mockConfig = {
       defaultPm: 'pnpm',
-    };
+    } as unknown as UnpmConfig;
     getConfigMock.mockResolvedValue(mockConfig);
 
     const result = await getDefaultPackageManager();

--- a/src/config/getDefaultPackageManager.ts
+++ b/src/config/getDefaultPackageManager.ts
@@ -1,5 +1,5 @@
-import { PackageManager } from "../packageManager/packageManager";
-import { getConfig } from "./getConfig";
+import { PackageManager } from '../packageManager/packageManager';
+import { getConfig } from './getConfig';
 
 export async function getDefaultPackageManager(): Promise<PackageManager> {
   const config = await getConfig();

--- a/src/config/getGlobalPackageManager.test.ts
+++ b/src/config/getGlobalPackageManager.test.ts
@@ -1,0 +1,64 @@
+import { getConfig } from './getConfig';
+import { PackageManager } from "../packageManager/packageManager";
+import { UnpmConfig } from './types';
+import { getGlobalPackageManager } from './getGlobalPackageManager';
+
+jest.mock('./getConfig');
+
+const getConfigMock = jest.mocked(getConfig);
+
+describe('config/getGlobalPackageManager', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('should return null if globalPm is null', async () => {
+    const mockConfig = {
+      globalPm: null,
+    } as unknown as UnpmConfig;
+
+    getConfigMock.mockResolvedValue(mockConfig);
+
+    const result = await getGlobalPackageManager();
+
+    expect(result).toBe(null);
+    expect(getConfigMock).toHaveBeenCalled();
+  });
+
+  it('should return PackageManager.NPM if globalPm is "npm"', async () => {
+    const mockConfig = {
+      globalPm: 'npm',
+    } as unknown as UnpmConfig;
+
+    getConfigMock.mockResolvedValue(mockConfig);
+
+    const result = await getGlobalPackageManager();
+
+    expect(result).toBe(PackageManager.NPM);
+    expect(getConfigMock).toHaveBeenCalled();
+  });
+
+  it('should return PackageManager.YARN if globalPm is "yarn"', async () => {
+    const mockConfig = {
+      globalPm: 'yarn',
+    } as unknown as UnpmConfig;
+    getConfigMock.mockResolvedValue(mockConfig);
+
+    const result = await getGlobalPackageManager();
+
+    expect(result).toBe(PackageManager.YARN);
+    expect(getConfigMock).toHaveBeenCalled();
+  });
+
+  it('should return PackageManager.PNPM if globalPm is "pnpm"', async () => {
+    const mockConfig = {
+      globalPm: 'pnpm',
+    } as unknown as UnpmConfig;
+    getConfigMock.mockResolvedValue(mockConfig);
+
+    const result = await getGlobalPackageManager();
+
+    expect(result).toBe(PackageManager.PNPM);
+    expect(getConfigMock).toHaveBeenCalled();
+  });
+});

--- a/src/config/getGlobalPackageManager.test.ts
+++ b/src/config/getGlobalPackageManager.test.ts
@@ -1,5 +1,5 @@
 import { getConfig } from './getConfig';
-import { PackageManager } from "../packageManager/packageManager";
+import { PackageManager } from '../packageManager/packageManager';
 import { UnpmConfig } from './types';
 import { getGlobalPackageManager } from './getGlobalPackageManager';
 

--- a/src/config/getGlobalPackageManager.ts
+++ b/src/config/getGlobalPackageManager.ts
@@ -1,5 +1,5 @@
-import { PackageManager } from "../packageManager/packageManager";
-import { getConfig } from "./getConfig";
+import { PackageManager } from '../packageManager/packageManager';
+import { getConfig } from './getConfig';
 
 export async function getGlobalPackageManager(): Promise<PackageManager | null> {
   const config = await getConfig();

--- a/src/config/getGlobalPackageManager.ts
+++ b/src/config/getGlobalPackageManager.ts
@@ -1,0 +1,17 @@
+import { PackageManager } from "../packageManager/packageManager";
+import { getConfig } from "./getConfig";
+
+export async function getGlobalPackageManager(): Promise<PackageManager | null> {
+  const config = await getConfig();
+
+  switch (config.globalPm) {
+    case 'npm':
+      return PackageManager.NPM;
+    case 'yarn':
+      return PackageManager.YARN;
+    case 'pnpm':
+      return PackageManager.PNPM;
+    default:
+      return null;
+  }
+}

--- a/src/config/internal/constants.ts
+++ b/src/config/internal/constants.ts
@@ -9,4 +9,5 @@ export const configFileLocation = resolve(homeDir, '.unpmrc');
 
 export const defaultConfig: Readonly<UnpmConfig> = {
   defaultPm: 'npm',
+  globalPm: 'npm',
 };

--- a/src/config/internal/createConfigFile.test.ts
+++ b/src/config/internal/createConfigFile.test.ts
@@ -25,7 +25,10 @@ describe('config/internal/createConfigFile', () => {
 
     await createConfigFile();
 
-    expect(writeFile).toHaveBeenCalledWith(configFileLocation, JSON.stringify(expectedConfig, null, 2));
+    expect(writeFile).toHaveBeenCalledWith(
+      configFileLocation,
+      JSON.stringify(expectedConfig, null, 2),
+    );
   });
 
   it('should create a config file with merged config if init is provided', async () => {
@@ -34,14 +37,23 @@ describe('config/internal/createConfigFile', () => {
 
     await createConfigFile(mockInit);
 
-    expect(writeFile).toHaveBeenCalledWith(configFileLocation, JSON.stringify(expectedConfig, null, 2));
+    expect(writeFile).toHaveBeenCalledWith(
+      configFileLocation,
+      JSON.stringify(expectedConfig, null, 2),
+    );
   });
 
   it('should throw an error if the config fails validation', async () => {
     const mockErrors: ErrorObject[] = [];
     validateConfigMock.mockResolvedValue(mockErrors);
 
-    await expect(createConfigFile(mockInit)).rejects.toThrow(`Initial config failed the validation, errors: ${JSON.stringify(mockErrors, null, 2)}`);
+    await expect(createConfigFile(mockInit)).rejects.toThrow(
+      `Initial config failed the validation, errors: ${JSON.stringify(
+        mockErrors,
+        null,
+        2,
+      )}`,
+    );
 
     expect(writeFile).not.toHaveBeenCalled();
   });

--- a/src/config/internal/createConfigFile.ts
+++ b/src/config/internal/createConfigFile.ts
@@ -3,13 +3,21 @@ import { UnpmConfig } from '../types';
 import { configFileLocation, defaultConfig } from './constants';
 import { validateConfig } from './validateConfig';
 
-export async function createConfigFile(init?: Partial<UnpmConfig>): Promise<UnpmConfig> {
+export async function createConfigFile(
+  init?: Partial<UnpmConfig>,
+): Promise<UnpmConfig> {
   const newConfig = { ...defaultConfig, ...(init ?? {}) };
 
   const newConfigErrors = await validateConfig(newConfig);
 
   if (newConfigErrors) {
-    throw new Error(`Initial config failed the validation, errors: ${JSON.stringify(newConfigErrors, null, 2)}`);
+    throw new Error(
+      `Initial config failed the validation, errors: ${JSON.stringify(
+        newConfigErrors,
+        null,
+        2,
+      )}`,
+    );
   }
 
   await writeFile(configFileLocation, JSON.stringify(newConfig, null, 2));

--- a/src/config/internal/createConfigFileIfNotExists.ts
+++ b/src/config/internal/createConfigFileIfNotExists.ts
@@ -2,8 +2,10 @@ import { UnpmConfig } from '../types';
 import { doesConfigFileExist } from './doesConfigFileExist';
 import { createConfigFile } from './createConfigFile';
 
-export async function createConfigFileIfNotExists(init?: Partial<UnpmConfig>): Promise<UnpmConfig | null> {
-  if (!await doesConfigFileExist()) {
+export async function createConfigFileIfNotExists(
+  init?: Partial<UnpmConfig>,
+): Promise<UnpmConfig | null> {
+  if (!(await doesConfigFileExist())) {
     return createConfigFile(init);
   }
 

--- a/src/config/internal/doesConfigFileExist.ts
+++ b/src/config/internal/doesConfigFileExist.ts
@@ -2,8 +2,9 @@ import { access } from 'fs/promises';
 import { configFileLocation } from './constants';
 
 export function doesConfigFileExist(): Promise<boolean> {
-  return new Promise(resolve => access(configFileLocation)
-    .then(() => resolve(true))
-    .catch(() => resolve(false))
+  return new Promise(resolve =>
+    access(configFileLocation)
+      .then(() => resolve(true))
+      .catch(() => resolve(false)),
   );
 }

--- a/src/config/internal/readConfigFile.test.ts
+++ b/src/config/internal/readConfigFile.test.ts
@@ -22,6 +22,7 @@ describe('config/internal/readConfigFile', () => {
   it('should return config if the config file is valid', async () => {
     const validConfig: UnpmConfig = {
       defaultPm: 'yarn',
+      globalPm: null,
     };
     readFileMock.mockResolvedValue(JSON.stringify(validConfig));
     validateConfigMock.mockResolvedValue(null);

--- a/src/config/internal/readConfigFile.test.ts
+++ b/src/config/internal/readConfigFile.test.ts
@@ -8,7 +8,7 @@ import { printError } from '../../io/printError';
 
 jest.mock('fs/promises');
 jest.mock('./validateConfig');
-jest.mock('../../io/printError')
+jest.mock('../../io/printError');
 
 const readFileMock = jest.mocked(readFile);
 const validateConfigMock = jest.mocked(validateConfig);
@@ -46,7 +46,11 @@ describe('config/internal/readConfigFile', () => {
     expect(readFileMock).toHaveBeenCalledWith(configFileLocation, 'utf-8');
     expect(validateConfigMock).toHaveBeenCalled();
     expect(printErrorMock).toHaveBeenCalledWith(
-      `Error: config file is broken, using fallback to the default config, errors: ${JSON.stringify(validationErrors, null, 2)}`
+      `Error: config file is broken, using fallback to the default config, errors: ${JSON.stringify(
+        validationErrors,
+        null,
+        2,
+      )}`,
     );
     expect(result).toEqual(defaultConfig);
 

--- a/src/config/internal/readConfigFile.ts
+++ b/src/config/internal/readConfigFile.ts
@@ -10,7 +10,13 @@ export async function readConfigFile(): Promise<UnpmConfig> {
   const validationErrors = await validateConfig(config);
 
   if (validationErrors) {
-    printError(`Error: config file is broken, using fallback to the default config, errors: ${JSON.stringify(validationErrors, null, 2)}`);
+    printError(
+      `Error: config file is broken, using fallback to the default config, errors: ${JSON.stringify(
+        validationErrors,
+        null,
+        2,
+      )}`,
+    );
 
     return defaultConfig;
   }

--- a/src/config/internal/updateConfigFile.test.ts
+++ b/src/config/internal/updateConfigFile.test.ts
@@ -12,7 +12,7 @@ const validateConfigMock = jest.mocked(validateConfig);
 
 describe('config/internal/updateConfigFile', () => {
   const currentConfig: UnpmConfig = {
-    ...defaultConfig
+    ...defaultConfig,
   };
 
   const updatedConfig: Partial<UnpmConfig> = {
@@ -33,8 +33,14 @@ describe('config/internal/updateConfigFile', () => {
 
     expect(readFile).toHaveBeenCalledWith(configFileLocation, 'utf-8');
     expect(validateConfig).toHaveBeenNthCalledWith(1, currentConfig);
-    expect(validateConfig).toHaveBeenNthCalledWith(2, { ...currentConfig, ...updatedConfig });
-    expect(writeFile).toHaveBeenCalledWith(configFileLocation, JSON.stringify({ ...currentConfig, ...updatedConfig }, null, 2));
+    expect(validateConfig).toHaveBeenNthCalledWith(2, {
+      ...currentConfig,
+      ...updatedConfig,
+    });
+    expect(writeFile).toHaveBeenCalledWith(
+      configFileLocation,
+      JSON.stringify({ ...currentConfig, ...updatedConfig }, null, 2),
+    );
     expect(newConfig).toEqual({ ...currentConfig, ...updatedConfig });
   });
 

--- a/src/config/internal/updateConfigFile.ts
+++ b/src/config/internal/updateConfigFile.ts
@@ -3,13 +3,23 @@ import { UnpmConfig } from '../types';
 import { configFileLocation } from './constants';
 import { validateConfig } from './validateConfig';
 
-export async function updateConfigFile(init: Partial<UnpmConfig>): Promise<UnpmConfig> {
-  const currentConfig = await readFile(configFileLocation, 'utf-8').then(JSON.parse);
+export async function updateConfigFile(
+  init: Partial<UnpmConfig>,
+): Promise<UnpmConfig> {
+  const currentConfig = await readFile(configFileLocation, 'utf-8').then(
+    JSON.parse,
+  );
 
   const currentConfigErrors = await validateConfig(currentConfig);
 
   if (currentConfigErrors) {
-    throw new Error(`Config file is broken, updating impossible, errors: ${JSON.stringify(currentConfigErrors, null, 2)}`);
+    throw new Error(
+      `Config file is broken, updating impossible, errors: ${JSON.stringify(
+        currentConfigErrors,
+        null,
+        2,
+      )}`,
+    );
   }
 
   const newConfig = { ...currentConfig, ...init };
@@ -17,7 +27,13 @@ export async function updateConfigFile(init: Partial<UnpmConfig>): Promise<UnpmC
   const newConfigErrors = await validateConfig(newConfig);
 
   if (newConfigErrors) {
-    throw new Error(`Updated config failed the validation, errors: ${JSON.stringify(newConfigErrors, null, 2)}`);
+    throw new Error(
+      `Updated config failed the validation, errors: ${JSON.stringify(
+        newConfigErrors,
+        null,
+        2,
+      )}`,
+    );
   }
 
   await writeFile(configFileLocation, JSON.stringify(newConfig, null, 2));

--- a/src/config/internal/validateConfig.test.ts
+++ b/src/config/internal/validateConfig.test.ts
@@ -5,6 +5,7 @@ describe('config/internal/validateConfig', () => {
   it('should return null if the config is valid', async () => {
     const validConfig: UnpmConfig = {
       defaultPm: 'yarn',
+      globalPm: null,
     };
 
     const result = await validateConfig(validConfig);

--- a/src/config/internal/validateConfig.ts
+++ b/src/config/internal/validateConfig.ts
@@ -1,6 +1,12 @@
 import Ajv, { JSONSchemaType } from 'ajv';
 import { UnpmConfig } from '../types';
 
+const globalPmSchema: JSONSchemaType<UnpmConfig['globalPm']> = {
+  type: 'string',
+  nullable: true,
+  enum: ['npm', 'yarn', 'pnpm', null],
+};
+
 const configSchema: JSONSchemaType<UnpmConfig> = {
   type: 'object',
   properties: {
@@ -8,8 +14,9 @@ const configSchema: JSONSchemaType<UnpmConfig> = {
       type: 'string',
       enum: ['npm', 'yarn', 'pnpm'],
     },
+    globalPm: globalPmSchema,
   },
-  required: ['defaultPm'],
+  required: ['defaultPm', 'globalPm'],
 }
 
 export async function validateConfig(config: UnpmConfig) {

--- a/src/config/internal/validateConfig.ts
+++ b/src/config/internal/validateConfig.ts
@@ -17,7 +17,7 @@ const configSchema: JSONSchemaType<UnpmConfig> = {
     globalPm: globalPmSchema,
   },
   required: ['defaultPm', 'globalPm'],
-}
+};
 
 export async function validateConfig(config: UnpmConfig) {
   const ajv = new Ajv();

--- a/src/config/setDefaultPackageManager.test.ts
+++ b/src/config/setDefaultPackageManager.test.ts
@@ -1,6 +1,6 @@
 import { setDefaultPackageManager } from './setDefaultPackageManager';
 import { updateConfig } from './updateConfig';
-import { PackageManager } from "../packageManager/packageManager";
+import { PackageManager } from '../packageManager/packageManager';
 
 jest.mock('./updateConfig');
 
@@ -16,6 +16,8 @@ describe('config/setDefaultPackageManager', () => {
 
     await setDefaultPackageManager(mockPackageManager);
 
-    expect(updateConfigMock).toHaveBeenCalledWith({ defaultPm: mockPackageManager });
+    expect(updateConfigMock).toHaveBeenCalledWith({
+      defaultPm: mockPackageManager,
+    });
   });
 });

--- a/src/config/setDefaultPackageManager.ts
+++ b/src/config/setDefaultPackageManager.ts
@@ -1,6 +1,8 @@
-import { PackageManager } from "../packageManager/packageManager";
-import { updateConfig } from "./updateConfig";
+import { PackageManager } from '../packageManager/packageManager';
+import { updateConfig } from './updateConfig';
 
-export async function setDefaultPackageManager(packageManager: PackageManager): Promise<void> {
-  await updateConfig({ defaultPm: packageManager })
+export async function setDefaultPackageManager(
+  packageManager: PackageManager,
+): Promise<void> {
+  await updateConfig({ defaultPm: packageManager });
 }

--- a/src/config/setGlobalPackageManager.test.ts
+++ b/src/config/setGlobalPackageManager.test.ts
@@ -1,5 +1,5 @@
 import { updateConfig } from './updateConfig';
-import { PackageManager } from "../packageManager/packageManager";
+import { PackageManager } from '../packageManager/packageManager';
 import { setGlobalPackageManager } from './setGlobalPackageManager';
 
 jest.mock('./updateConfig');
@@ -16,6 +16,8 @@ describe('config/setGlobalPackageManager', () => {
 
     await setGlobalPackageManager(mockPackageManager);
 
-    expect(updateConfigMock).toHaveBeenCalledWith({ globalPm: mockPackageManager });
+    expect(updateConfigMock).toHaveBeenCalledWith({
+      globalPm: mockPackageManager,
+    });
   });
 });

--- a/src/config/setGlobalPackageManager.test.ts
+++ b/src/config/setGlobalPackageManager.test.ts
@@ -1,0 +1,21 @@
+import { updateConfig } from './updateConfig';
+import { PackageManager } from "../packageManager/packageManager";
+import { setGlobalPackageManager } from './setGlobalPackageManager';
+
+jest.mock('./updateConfig');
+
+const updateConfigMock = jest.mocked(updateConfig);
+
+describe('config/setGlobalPackageManager', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('should call updateConfigFile with the correct argument', async () => {
+    const mockPackageManager = PackageManager.YARN;
+
+    await setGlobalPackageManager(mockPackageManager);
+
+    expect(updateConfigMock).toHaveBeenCalledWith({ globalPm: mockPackageManager });
+  });
+});

--- a/src/config/setGlobalPackageManager.ts
+++ b/src/config/setGlobalPackageManager.ts
@@ -1,0 +1,6 @@
+import { PackageManager } from "../packageManager/packageManager";
+import { updateConfig } from "./updateConfig";
+
+export async function setGlobalPackageManager(packageManager: PackageManager | null): Promise<void> {
+  await updateConfig({ globalPm: packageManager })
+}

--- a/src/config/setGlobalPackageManager.ts
+++ b/src/config/setGlobalPackageManager.ts
@@ -1,6 +1,8 @@
-import { PackageManager } from "../packageManager/packageManager";
-import { updateConfig } from "./updateConfig";
+import { PackageManager } from '../packageManager/packageManager';
+import { updateConfig } from './updateConfig';
 
-export async function setGlobalPackageManager(packageManager: PackageManager | null): Promise<void> {
-  await updateConfig({ globalPm: packageManager })
+export async function setGlobalPackageManager(
+  packageManager: PackageManager | null,
+): Promise<void> {
+  await updateConfig({ globalPm: packageManager });
 }

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -1,3 +1,4 @@
 export type UnpmConfig = {
   defaultPm: 'npm' | 'yarn' | 'pnpm';
+  globalPm: 'npm' | 'yarn' | 'pnpm' | null;
 };

--- a/src/config/updateConfig.test.ts
+++ b/src/config/updateConfig.test.ts
@@ -8,7 +8,9 @@ import { createConfigFileIfNotExists } from './internal/createConfigFileIfNotExi
 jest.mock('./internal/createConfigFileIfNotExists');
 jest.mock('./internal/updateConfigFile');
 
-const createConfigFileIfNotExistsMock = jest.mocked(createConfigFileIfNotExists);
+const createConfigFileIfNotExistsMock = jest.mocked(
+  createConfigFileIfNotExists,
+);
 const updateConfigFileMock = jest.mocked(updateConfigFile);
 
 describe('config/updateConfig', () => {
@@ -34,8 +36,6 @@ describe('config/updateConfig', () => {
     expect(createConfigFileIfNotExistsMock).toHaveBeenCalled();
     expect(updateConfigFileMock).not.toHaveBeenCalled();
   });
-
-
 
   it('should call updateConfigFile and return its result if createConfigFileIfNotExists returns nullish', async () => {
     createConfigFileIfNotExistsMock.mockResolvedValue(null);

--- a/src/config/updateConfig.ts
+++ b/src/config/updateConfig.ts
@@ -2,6 +2,10 @@ import { createConfigFileIfNotExists } from './internal/createConfigFileIfNotExi
 import { updateConfigFile } from './internal/updateConfigFile';
 import { UnpmConfig } from './types';
 
-export async function updateConfig(init: Partial<UnpmConfig>): Promise<UnpmConfig> {
-  return await createConfigFileIfNotExists(init) ?? await updateConfigFile(init);
+export async function updateConfig(
+  init: Partial<UnpmConfig>,
+): Promise<UnpmConfig> {
+  return (
+    (await createConfigFileIfNotExists(init)) ?? (await updateConfigFile(init))
+  );
 }

--- a/src/entryPoints/unpm.test.ts
+++ b/src/entryPoints/unpm.test.ts
@@ -12,10 +12,18 @@ jest.mock('../subEntryPoints/version');
 
 jest.mock('../subEntryPoints/command');
 
-const getNodeVersionMock = jest.mocked(getNodeVersion).mockReturnValue('v14.7.0');
-const runHelpSubEntryPointMock = jest.mocked(runHelpSubEntryPoint).mockResolvedValue();
-const runVersionSubEntryPointMock = jest.mocked(runVersionSubEntryPoint).mockResolvedValue();
-const runCommandSubEntryPointMock = jest.mocked(runCommandSubEntryPoint).mockResolvedValue();
+const getNodeVersionMock = jest
+  .mocked(getNodeVersion)
+  .mockReturnValue('v14.7.0');
+const runHelpSubEntryPointMock = jest
+  .mocked(runHelpSubEntryPoint)
+  .mockResolvedValue();
+const runVersionSubEntryPointMock = jest
+  .mocked(runVersionSubEntryPoint)
+  .mockResolvedValue();
+const runCommandSubEntryPointMock = jest
+  .mocked(runCommandSubEntryPoint)
+  .mockResolvedValue();
 
 describe('entryPoints/unpm', () => {
   beforeEach(() => {
@@ -25,62 +33,74 @@ describe('entryPoints/unpm', () => {
   it('should reject when Node.js version is lower than v14.6', async () => {
     getNodeVersionMock.mockReturnValueOnce('v14.5.0');
 
-    await expect(run).toThrowError(new Error(`This version of unpm requires at least Node.js v14.6\nThe current version of Node.js is ${process.version}`));
+    await expect(run).toThrowError(
+      new Error(
+        `This version of unpm requires at least Node.js v14.6\nThe current version of Node.js is ${process.version}`,
+      ),
+    );
 
     expect(runHelpSubEntryPointMock).toHaveBeenCalledTimes(0);
     expect(runVersionSubEntryPointMock).toHaveBeenCalledTimes(0);
     expect(runCommandSubEntryPointMock).toHaveBeenCalledTimes(0);
   });
 
-  it.each(
-    ['--help', '--h', '-help', '-h', 'help', 'h']
-  )('should call the "help" sub entry point when second argument is "help" compatible: %s', async (argv2) => {
-    const argv = [...process.argv];
-    argv[2] = argv2;
+  it.each(['--help', '--h', '-help', '-h', 'help', 'h'])(
+    'should call the "help" sub entry point when second argument is "help" compatible: %s',
+    async argv2 => {
+      const argv = [...process.argv];
+      argv[2] = argv2;
 
-    await run(argv);
+      await run(argv);
 
-    expect(runHelpSubEntryPointMock).toHaveBeenCalledTimes(1);
-    expect(runVersionSubEntryPointMock).toHaveBeenCalledTimes(0);
-    expect(runCommandSubEntryPointMock).toHaveBeenCalledTimes(0);
-  });
+      expect(runHelpSubEntryPointMock).toHaveBeenCalledTimes(1);
+      expect(runVersionSubEntryPointMock).toHaveBeenCalledTimes(0);
+      expect(runCommandSubEntryPointMock).toHaveBeenCalledTimes(0);
+    },
+  );
 
-  it.each(
-    ['--version', '--v', '-version', '-v']
-  )('should call the "help" sub entry point when second argument is "version" compatible: %s', async (argv2) => {
-    const argv = [...process.argv];
-    argv[2] = argv2;
+  it.each(['--version', '--v', '-version', '-v'])(
+    'should call the "help" sub entry point when second argument is "version" compatible: %s',
+    async argv2 => {
+      const argv = [...process.argv];
+      argv[2] = argv2;
 
-    await run(argv);
+      await run(argv);
 
-    expect(runHelpSubEntryPointMock).toHaveBeenCalledTimes(0);
-    expect(runVersionSubEntryPointMock).toHaveBeenCalledTimes(1);
-    expect(runCommandSubEntryPointMock).toHaveBeenCalledTimes(0);
-  });
+      expect(runHelpSubEntryPointMock).toHaveBeenCalledTimes(0);
+      expect(runVersionSubEntryPointMock).toHaveBeenCalledTimes(1);
+      expect(runCommandSubEntryPointMock).toHaveBeenCalledTimes(0);
+    },
+  );
 
-  it.each(
-    ['-D']
-  )('should reject when second argument is invalid: %s', async (argv2) => {
-    const argv = [...process.argv];
-    argv[2] = argv2;
+  it.each(['-D'])(
+    'should reject when second argument is invalid: %s',
+    async argv2 => {
+      const argv = [...process.argv];
+      argv[2] = argv2;
 
-    await expect(() => run(argv)).toThrowError(new Error('Second argument must be: "--help", "--version" or command to invoke (or none if just called as "unpm" to install all packages)'));
+      await expect(() => run(argv)).toThrowError(
+        new Error(
+          'Second argument must be: "--help", "--version" or command to invoke (or none if just called as "unpm" to install all packages)',
+        ),
+      );
 
-    expect(runHelpSubEntryPointMock).toHaveBeenCalledTimes(0);
-    expect(runVersionSubEntryPointMock).toHaveBeenCalledTimes(0);
-    expect(runCommandSubEntryPointMock).toHaveBeenCalledTimes(0);
-  });
+      expect(runHelpSubEntryPointMock).toHaveBeenCalledTimes(0);
+      expect(runVersionSubEntryPointMock).toHaveBeenCalledTimes(0);
+      expect(runCommandSubEntryPointMock).toHaveBeenCalledTimes(0);
+    },
+  );
 
-  it.each(
-    ['', 'run', 'install', 'version', 'config']
-  )('should call the "command" sub entry point for other seconds argument values: %s', async (argv2) => {
-    const argv = [...process.argv];
-    argv[2] = argv2;
+  it.each(['', 'run', 'install', 'version', 'config'])(
+    'should call the "command" sub entry point for other seconds argument values: %s',
+    async argv2 => {
+      const argv = [...process.argv];
+      argv[2] = argv2;
 
-    await run(argv);
+      await run(argv);
 
-    expect(runHelpSubEntryPointMock).toHaveBeenCalledTimes(0);
-    expect(runVersionSubEntryPointMock).toHaveBeenCalledTimes(0);
-    expect(runCommandSubEntryPointMock).toHaveBeenCalledTimes(1);
-  });
+      expect(runHelpSubEntryPointMock).toHaveBeenCalledTimes(0);
+      expect(runVersionSubEntryPointMock).toHaveBeenCalledTimes(0);
+      expect(runCommandSubEntryPointMock).toHaveBeenCalledTimes(1);
+    },
+  );
 });

--- a/src/entryPoints/unpm.ts
+++ b/src/entryPoints/unpm.ts
@@ -1,10 +1,15 @@
 import { getNodeVersion } from '../process/getNodeVersion';
 
 export default function run(argv: string[]): Promise<void> {
-  const [major = 0, minor = 0] = getNodeVersion().slice(1).split('.').map(Number);
+  const [major = 0, minor = 0] = getNodeVersion()
+    .slice(1)
+    .split('.')
+    .map(Number);
 
-  if (major < 14 || major == 14 && minor < 6) {
-    throw new Error(`This version of unpm requires at least Node.js v14.6\nThe current version of Node.js is ${process.version}`);
+  if (major < 14 || (major == 14 && minor < 6)) {
+    throw new Error(
+      `This version of unpm requires at least Node.js v14.6\nThe current version of Node.js is ${process.version}`,
+    );
   }
 
   const argv2 = argv[2];
@@ -18,7 +23,9 @@ export default function run(argv: string[]): Promise<void> {
   }
 
   if (argv2?.startsWith('-')) {
-    throw new Error('Second argument must be: "--help", "--version" or command to invoke (or none if just called as "unpm" to install all packages)');
+    throw new Error(
+      'Second argument must be: "--help", "--version" or command to invoke (or none if just called as "unpm" to install all packages)',
+    );
   }
 
   return import('../subEntryPoints/command').then(m => m.default(argv, argv2));

--- a/src/errors/NotSupportedError.test.ts
+++ b/src/errors/NotSupportedError.test.ts
@@ -1,5 +1,5 @@
 import { NotSupportedError } from './NotSupportedError';
-import { PackageManager } from "../packageManager/packageManager";
+import { PackageManager } from '../packageManager/packageManager';
 
 describe('errors/NotSupportedError', () => {
   it('should construct a valid error message with one package manager', () => {
@@ -8,7 +8,9 @@ describe('errors/NotSupportedError', () => {
 
     const error = new NotSupportedError(subject, packageManager);
 
-    expect(error.message).toBe(`"${subject}" is not supported by ${packageManager}`);
+    expect(error.message).toBe(
+      `"${subject}" is not supported by ${packageManager}`,
+    );
     expect(error.subject).toBe(subject);
     expect(error.packageManagers).toEqual([packageManager]);
   });
@@ -19,7 +21,9 @@ describe('errors/NotSupportedError', () => {
 
     const error = new NotSupportedError(subject, packageManagers);
 
-    expect(error.message).toBe(`"${subject}" is not supported by ${packageManagers.join(', ')}`);
+    expect(error.message).toBe(
+      `"${subject}" is not supported by ${packageManagers.join(', ')}`,
+    );
     expect(error.subject).toBe(subject);
     expect(error.packageManagers).toEqual(packageManagers);
   });

--- a/src/errors/NotSupportedError.ts
+++ b/src/errors/NotSupportedError.ts
@@ -1,12 +1,17 @@
-import { PackageManager } from "../packageManager/packageManager";
+import { PackageManager } from '../packageManager/packageManager';
 
 export class NotSupportedError extends Error {
   public readonly subject: string;
   public readonly packageManagers: ReadonlyArray<PackageManager>;
 
-  constructor(subject: string, packageManager: PackageManager | PackageManager[]) {
-    const packageManagers = Array.isArray(packageManager) ? packageManager : [packageManager];
-    
+  constructor(
+    subject: string,
+    packageManager: PackageManager | PackageManager[],
+  ) {
+    const packageManagers = Array.isArray(packageManager)
+      ? packageManager
+      : [packageManager];
+
     super(`"${subject}" is not supported by ${packageManagers.join(', ')}`);
 
     this.subject = subject;

--- a/src/errors/RestrictedCommandError.test.ts
+++ b/src/errors/RestrictedCommandError.test.ts
@@ -6,7 +6,9 @@ describe('errors/RestrictedCommandError', () => {
 
     const error = new RestrictedCommandError(commandName);
 
-    expect(error.message).toBe(`"${commandName}" command is not implemented by unpm, please use your package manager directly for it`);
+    expect(error.message).toBe(
+      `"${commandName}" command is not implemented by unpm, please use your package manager directly for it`,
+    );
   });
 
   it('should construct a valid error message with a command name and a reason', () => {
@@ -15,6 +17,8 @@ describe('errors/RestrictedCommandError', () => {
 
     const error = new RestrictedCommandError(commandName, reason);
 
-    expect(error.message).toBe(`"${commandName}" command is not implemented by unpm, please use your package manager directly for it, reason: "${reason}"`);
+    expect(error.message).toBe(
+      `"${commandName}" command is not implemented by unpm, please use your package manager directly for it, reason: "${reason}"`,
+    );
   });
 });

--- a/src/errors/RestrictedCommandError.ts
+++ b/src/errors/RestrictedCommandError.ts
@@ -2,6 +2,8 @@ export class RestrictedCommandError extends Error {
   constructor(commandName: string, reason?: string) {
     const addition = reason ? `, reason: "${reason}"` : '';
 
-    super(`"${commandName}" command is not implemented by unpm, please use your package manager directly for it${addition}`);
+    super(
+      `"${commandName}" command is not implemented by unpm, please use your package manager directly for it${addition}`,
+    );
   }
 }

--- a/src/io/executeCommand.test.ts
+++ b/src/io/executeCommand.test.ts
@@ -5,12 +5,19 @@ jest.mock('child_process');
 
 const execMock = jest.mocked(exec);
 
-type ExecCallback = (error: ExecException | null, stdout: string, stderr: string) => void;
+type ExecCallback = (
+  error: ExecException | null,
+  stdout: string,
+  stderr: string,
+) => void;
 
 describe('io/executeCommand', () => {
-  jest.spyOn(process, 'stdin', 'get').mockImplementation(() => ({
-    pipe: jest.fn(),
-  }) as unknown as NodeJS.ReadStream & { fd: 0; });
+  jest.spyOn(process, 'stdin', 'get').mockImplementation(
+    () =>
+      ({
+        pipe: jest.fn(),
+      } as unknown as NodeJS.ReadStream & { fd: 0 }),
+  );
 
   afterEach(() => {
     jest.clearAllMocks();
@@ -23,8 +30,13 @@ describe('io/executeCommand', () => {
       return {} as unknown as ChildProcess;
     });
 
-    await expect(executeCommand('echo "Hello, World!"')).resolves.toBeUndefined();
-    expect(exec).toHaveBeenCalledWith('echo "Hello, World!"', expect.any(Function));
+    await expect(
+      executeCommand('echo "Hello, World!"'),
+    ).resolves.toBeUndefined();
+    expect(exec).toHaveBeenCalledWith(
+      'echo "Hello, World!"',
+      expect.any(Function),
+    );
   });
 
   it('should reject with error, stdout, and stderr when the command execution fails', async () => {
@@ -38,8 +50,15 @@ describe('io/executeCommand', () => {
       return {} as unknown as ChildProcess;
     });
 
-    await expect(executeCommand('nonexistent-command')).rejects.toEqual({ error, stdout, stderr });
-    expect(exec).toHaveBeenCalledWith('nonexistent-command', expect.any(Function));
+    await expect(executeCommand('nonexistent-command')).rejects.toEqual({
+      error,
+      stdout,
+      stderr,
+    });
+    expect(exec).toHaveBeenCalledWith(
+      'nonexistent-command',
+      expect.any(Function),
+    );
   });
 
   it('should pipe stdout and stderr to process stdout and stderr', () => {
@@ -47,7 +66,10 @@ describe('io/executeCommand', () => {
     const stderrMock = { pipe: jest.fn() };
 
     execMock.mockImplementation(() => {
-      return { stdout: stdoutMock, stderr: stderrMock } as unknown as ChildProcess;
+      return {
+        stdout: stdoutMock,
+        stderr: stderrMock,
+      } as unknown as ChildProcess;
     });
 
     executeCommand('echo "Hello, World!"');

--- a/src/io/printError.test.ts
+++ b/src/io/printError.test.ts
@@ -1,12 +1,16 @@
-import { printError } from "./printError";
+import { printError } from './printError';
 
 describe('io/printError', () => {
   it('should call console.error with passed error', () => {
-    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => { /* */});
+    const consoleErrorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {
+        /* */
+      });
     const error = 'Error';
 
     printError(error);
 
     expect(consoleErrorSpy).toHaveBeenCalledWith(error);
-  })
-})
+  });
+});

--- a/src/io/printText.test.ts
+++ b/src/io/printText.test.ts
@@ -1,12 +1,14 @@
-import { printText } from "./printText";
+import { printText } from './printText';
 
 describe('io/printText', () => {
   it('should call console.log with passed error', () => {
-    const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => { /* */});
+    const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {
+      /* */
+    });
     const text = 'Text';
 
     printText(text);
 
     expect(consoleLogSpy).toHaveBeenCalledWith(text);
-  })
-})
+  });
+});

--- a/src/packageManager/getGlobalPackageManager.test.ts
+++ b/src/packageManager/getGlobalPackageManager.test.ts
@@ -1,12 +1,14 @@
-import { PackageManager } from "./packageManager";
+import { PackageManager } from './packageManager';
 import { getGlobalPackageManager as getConfigGlobalPackageManager } from '../config/getGlobalPackageManager';
-import { getDefaultPackageManager } from "../config/getDefaultPackageManager";
-import { getGlobalPackageManager } from "./getGlobalPackageManager";
+import { getDefaultPackageManager } from '../config/getDefaultPackageManager';
+import { getGlobalPackageManager } from './getGlobalPackageManager';
 
 jest.mock('../config/getGlobalPackageManager');
 jest.mock('../config/getDefaultPackageManager');
 
-const getConfigGlobalPackageManagerMock = jest.mocked(getConfigGlobalPackageManager);
+const getConfigGlobalPackageManagerMock = jest.mocked(
+  getConfigGlobalPackageManager,
+);
 const getDefaultPackageManagerMock = jest.mocked(getDefaultPackageManager);
 
 describe('packageManager/getGlobalPackageManager', () => {

--- a/src/packageManager/getGlobalPackageManager.test.ts
+++ b/src/packageManager/getGlobalPackageManager.test.ts
@@ -1,0 +1,45 @@
+import { PackageManager } from "./packageManager";
+import { getGlobalPackageManager as getConfigGlobalPackageManager } from '../config/getGlobalPackageManager';
+import { getDefaultPackageManager } from "../config/getDefaultPackageManager";
+import { getGlobalPackageManager } from "./getGlobalPackageManager";
+
+jest.mock('../config/getGlobalPackageManager');
+jest.mock('../config/getDefaultPackageManager');
+
+const getConfigGlobalPackageManagerMock = jest.mocked(getConfigGlobalPackageManager);
+const getDefaultPackageManagerMock = jest.mocked(getDefaultPackageManager);
+
+describe('packageManager/getGlobalPackageManager', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('returns the default package manager if the global package manager is not available', async () => {
+    getConfigGlobalPackageManagerMock.mockResolvedValue(null);
+    getDefaultPackageManagerMock.mockResolvedValue(PackageManager.PNPM);
+
+    const packageManager = await getGlobalPackageManager();
+    expect(packageManager).toBe(PackageManager.PNPM);
+  });
+
+  it('returns PackageManager.NPM when global package manager is npm', async () => {
+    getConfigGlobalPackageManagerMock.mockResolvedValue(PackageManager.NPM);
+
+    const packageManager = await getGlobalPackageManager();
+    expect(packageManager).toBe(PackageManager.NPM);
+  });
+
+  it('returns PackageManager.YARN when global package manager is yarn', async () => {
+    getConfigGlobalPackageManagerMock.mockResolvedValue(PackageManager.YARN);
+
+    const packageManager = await getGlobalPackageManager();
+    expect(packageManager).toBe(PackageManager.YARN);
+  });
+
+  it('returns PackageManager.PNPM when global package manager is pnpm', async () => {
+    getConfigGlobalPackageManagerMock.mockResolvedValue(PackageManager.PNPM);
+
+    const packageManager = await getGlobalPackageManager();
+    expect(packageManager).toBe(PackageManager.PNPM);
+  });
+});

--- a/src/packageManager/getGlobalPackageManager.ts
+++ b/src/packageManager/getGlobalPackageManager.ts
@@ -1,0 +1,8 @@
+import { getGlobalPackageManager as getConfigGlobalPackageManager } from '../config/getGlobalPackageManager';
+import { PackageManager } from "./packageManager";
+
+export async function getGlobalPackageManager(): Promise<PackageManager> {
+  const globalPackageManager = await getConfigGlobalPackageManager();
+
+  return globalPackageManager ?? import('../config/getDefaultPackageManager').then(m => m.getDefaultPackageManager());
+}

--- a/src/packageManager/getGlobalPackageManager.ts
+++ b/src/packageManager/getGlobalPackageManager.ts
@@ -1,8 +1,13 @@
 import { getGlobalPackageManager as getConfigGlobalPackageManager } from '../config/getGlobalPackageManager';
-import { PackageManager } from "./packageManager";
+import { PackageManager } from './packageManager';
 
 export async function getGlobalPackageManager(): Promise<PackageManager> {
   const globalPackageManager = await getConfigGlobalPackageManager();
 
-  return globalPackageManager ?? import('../config/getDefaultPackageManager').then(m => m.getDefaultPackageManager());
+  return (
+    globalPackageManager ??
+    import('../config/getDefaultPackageManager').then(m =>
+      m.getDefaultPackageManager(),
+    )
+  );
 }

--- a/src/packageManager/getPackageManager.test.ts
+++ b/src/packageManager/getPackageManager.test.ts
@@ -1,9 +1,10 @@
 import { PackageManager } from "./packageManager";
-import getPreferredPackageManager from 'preferred-pm';
+import { getPreferredPackageManager } from './getPreferredPackageManager';
 import { getDefaultPackageManager } from "../config/getDefaultPackageManager";
 import { getPackageManager } from './getPackageManager';
 
 jest.mock('preferred-pm');
+jest.mock('./getPreferredPackageManager');
 jest.mock('../config/getDefaultPackageManager');
 
 const getPreferredPackageManagerMock = jest.mocked(getPreferredPackageManager);
@@ -15,7 +16,7 @@ describe('packageManager/getPackageManager', () => {
   });
 
   it('returns the default package manager if the preferred package manager is not available', async () => {
-    getPreferredPackageManagerMock.mockResolvedValue(undefined);
+    getPreferredPackageManagerMock.mockResolvedValue(null);
     getDefaultPackageManagerMock.mockResolvedValue(PackageManager.PNPM);
 
     const packageManager = await getPackageManager();
@@ -23,21 +24,21 @@ describe('packageManager/getPackageManager', () => {
   });
 
   it('returns PackageManager.NPM when preferred package manager is npm', async () => {
-    getPreferredPackageManagerMock.mockResolvedValue({ name: 'npm', version: '' });
+    getPreferredPackageManagerMock.mockResolvedValue(PackageManager.NPM);
 
     const packageManager = await getPackageManager();
     expect(packageManager).toBe(PackageManager.NPM);
   });
 
   it('returns PackageManager.YARN when preferred package manager is yarn', async () => {
-    getPreferredPackageManagerMock.mockResolvedValue({ name: 'yarn', version: '' });
+    getPreferredPackageManagerMock.mockResolvedValue(PackageManager.YARN);
 
     const packageManager = await getPackageManager();
     expect(packageManager).toBe(PackageManager.YARN);
   });
 
   it('returns PackageManager.PNPM when preferred package manager is pnpm', async () => {
-    getPreferredPackageManagerMock.mockResolvedValue({ name: 'pnpm', version: '' });
+    getPreferredPackageManagerMock.mockResolvedValue(PackageManager.PNPM);
 
     const packageManager = await getPackageManager();
     expect(packageManager).toBe(PackageManager.PNPM);

--- a/src/packageManager/getPackageManager.test.ts
+++ b/src/packageManager/getPackageManager.test.ts
@@ -1,6 +1,6 @@
-import { PackageManager } from "./packageManager";
+import { PackageManager } from './packageManager';
 import { getPreferredPackageManager } from './getPreferredPackageManager';
-import { getDefaultPackageManager } from "../config/getDefaultPackageManager";
+import { getDefaultPackageManager } from '../config/getDefaultPackageManager';
 import { getPackageManager } from './getPackageManager';
 
 jest.mock('preferred-pm');

--- a/src/packageManager/getPackageManager.ts
+++ b/src/packageManager/getPackageManager.ts
@@ -1,8 +1,13 @@
-import { getPreferredPackageManager } from "./getPreferredPackageManager";
-import { PackageManager } from "./packageManager";
+import { getPreferredPackageManager } from './getPreferredPackageManager';
+import { PackageManager } from './packageManager';
 
 export async function getPackageManager(): Promise<PackageManager> {
   const preferredPackageManager = await getPreferredPackageManager();
 
-  return preferredPackageManager ?? import('../config/getDefaultPackageManager').then(m => m.getDefaultPackageManager());
+  return (
+    preferredPackageManager ??
+    import('../config/getDefaultPackageManager').then(m =>
+      m.getDefaultPackageManager(),
+    )
+  );
 }

--- a/src/packageManager/getPackageManager.ts
+++ b/src/packageManager/getPackageManager.ts
@@ -1,18 +1,8 @@
+import { getPreferredPackageManager } from "./getPreferredPackageManager";
 import { PackageManager } from "./packageManager";
-import getPreferredPackageManager from 'preferred-pm';
 
 export async function getPackageManager(): Promise<PackageManager> {
-   // returns `undefined`, if pm was not used before in `process.cwd()`
-  const preferredPackageManager = await getPreferredPackageManager(process.cwd());
+  const preferredPackageManager = await getPreferredPackageManager();
 
-  switch (preferredPackageManager?.name) {
-    case 'npm':
-      return PackageManager.NPM;
-    case 'yarn':
-      return PackageManager.YARN;
-    case 'pnpm':
-      return PackageManager.PNPM;
-    default:
-      return import('../config/getDefaultPackageManager').then(m => m.getDefaultPackageManager());
-  }
+  return preferredPackageManager ?? import('../config/getDefaultPackageManager').then(m => m.getDefaultPackageManager());
 }

--- a/src/packageManager/getPreferredPackageManager.test.ts
+++ b/src/packageManager/getPreferredPackageManager.test.ts
@@ -1,0 +1,41 @@
+import { PackageManager } from "./packageManager";
+import getPreferredPackageManager__Lib from 'preferred-pm';
+import { getPreferredPackageManager } from './getPreferredPackageManager';
+
+jest.mock('preferred-pm');
+
+const getPreferredPackageManagerMock = jest.mocked(getPreferredPackageManager__Lib);
+
+describe('packageManager/getPreferredPackageManager', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('returns the null if the preferred package manager is not available', async () => {
+    getPreferredPackageManagerMock.mockResolvedValue(undefined);
+
+    const packageManager = await getPreferredPackageManager();
+    expect(packageManager).toBe(null);
+  });
+
+  it('returns PackageManager.NPM when preferred package manager is npm', async () => {
+    getPreferredPackageManagerMock.mockResolvedValue({ name: 'npm', version: '' });
+
+    const packageManager = await getPreferredPackageManager();
+    expect(packageManager).toBe(PackageManager.NPM);
+  });
+
+  it('returns PackageManager.YARN when preferred package manager is yarn', async () => {
+    getPreferredPackageManagerMock.mockResolvedValue({ name: 'yarn', version: '' });
+
+    const packageManager = await getPreferredPackageManager();
+    expect(packageManager).toBe(PackageManager.YARN);
+  });
+
+  it('returns PackageManager.PNPM when preferred package manager is pnpm', async () => {
+    getPreferredPackageManagerMock.mockResolvedValue({ name: 'pnpm', version: '' });
+
+    const packageManager = await getPreferredPackageManager();
+    expect(packageManager).toBe(PackageManager.PNPM);
+  });
+});

--- a/src/packageManager/getPreferredPackageManager.test.ts
+++ b/src/packageManager/getPreferredPackageManager.test.ts
@@ -1,10 +1,12 @@
-import { PackageManager } from "./packageManager";
+import { PackageManager } from './packageManager';
 import getPreferredPackageManager__Lib from 'preferred-pm';
 import { getPreferredPackageManager } from './getPreferredPackageManager';
 
 jest.mock('preferred-pm');
 
-const getPreferredPackageManagerMock = jest.mocked(getPreferredPackageManager__Lib);
+const getPreferredPackageManagerMock = jest.mocked(
+  getPreferredPackageManager__Lib,
+);
 
 describe('packageManager/getPreferredPackageManager', () => {
   afterEach(() => {
@@ -19,21 +21,30 @@ describe('packageManager/getPreferredPackageManager', () => {
   });
 
   it('returns PackageManager.NPM when preferred package manager is npm', async () => {
-    getPreferredPackageManagerMock.mockResolvedValue({ name: 'npm', version: '' });
+    getPreferredPackageManagerMock.mockResolvedValue({
+      name: 'npm',
+      version: '',
+    });
 
     const packageManager = await getPreferredPackageManager();
     expect(packageManager).toBe(PackageManager.NPM);
   });
 
   it('returns PackageManager.YARN when preferred package manager is yarn', async () => {
-    getPreferredPackageManagerMock.mockResolvedValue({ name: 'yarn', version: '' });
+    getPreferredPackageManagerMock.mockResolvedValue({
+      name: 'yarn',
+      version: '',
+    });
 
     const packageManager = await getPreferredPackageManager();
     expect(packageManager).toBe(PackageManager.YARN);
   });
 
   it('returns PackageManager.PNPM when preferred package manager is pnpm', async () => {
-    getPreferredPackageManagerMock.mockResolvedValue({ name: 'pnpm', version: '' });
+    getPreferredPackageManagerMock.mockResolvedValue({
+      name: 'pnpm',
+      version: '',
+    });
 
     const packageManager = await getPreferredPackageManager();
     expect(packageManager).toBe(PackageManager.PNPM);

--- a/src/packageManager/getPreferredPackageManager.ts
+++ b/src/packageManager/getPreferredPackageManager.ts
@@ -1,0 +1,18 @@
+import { PackageManager } from "./packageManager";
+import getPreferredPackageManager__Lib from 'preferred-pm';
+
+export async function getPreferredPackageManager(): Promise<PackageManager | null> {
+   // returns `undefined`, if pm was not used before in `process.cwd()`
+  const preferredPackageManager = await getPreferredPackageManager__Lib(process.cwd());
+
+  switch (preferredPackageManager?.name) {
+    case 'npm':
+      return PackageManager.NPM;
+    case 'yarn':
+      return PackageManager.YARN;
+    case 'pnpm':
+      return PackageManager.PNPM;
+    default:
+      return null;
+  }
+}

--- a/src/packageManager/getPreferredPackageManager.ts
+++ b/src/packageManager/getPreferredPackageManager.ts
@@ -1,9 +1,11 @@
-import { PackageManager } from "./packageManager";
+import { PackageManager } from './packageManager';
 import getPreferredPackageManager__Lib from 'preferred-pm';
 
 export async function getPreferredPackageManager(): Promise<PackageManager | null> {
-   // returns `undefined`, if pm was not used before in `process.cwd()`
-  const preferredPackageManager = await getPreferredPackageManager__Lib(process.cwd());
+  // returns `undefined`, if pm was not used before in `process.cwd()`
+  const preferredPackageManager = await getPreferredPackageManager__Lib(
+    process.cwd(),
+  );
 
   switch (preferredPackageManager?.name) {
     case 'npm':

--- a/src/packageManager/isPackageManager.test.ts
+++ b/src/packageManager/isPackageManager.test.ts
@@ -1,5 +1,5 @@
 import { isPackageManager } from './isPackageManager';
-import { PackageManager } from "./packageManager";
+import { PackageManager } from './packageManager';
 
 describe('packageManager/isPackageManager', () => {
   it('should return null for non-string input', () => {

--- a/src/packageManager/isPackageManager.ts
+++ b/src/packageManager/isPackageManager.ts
@@ -1,4 +1,4 @@
-import { PackageManager } from "./packageManager";
+import { PackageManager } from './packageManager';
 
 export function isPackageManager(value: unknown): PackageManager | null {
   if (typeof value !== 'string') {

--- a/src/packageManager/packageManager.ts
+++ b/src/packageManager/packageManager.ts
@@ -1,7 +1,7 @@
 export enum PackageManager {
   NPM = 'npm',
   YARN = 'yarn',
-  PNPM = 'pnpm'
+  PNPM = 'pnpm',
 }
 
 export const PackageManagers: ReadonlySet<PackageManager> = new Set([

--- a/src/packageManager/packageManager.ts
+++ b/src/packageManager/packageManager.ts
@@ -3,3 +3,9 @@ export enum PackageManager {
   YARN = 'yarn',
   PNPM = 'pnpm'
 }
+
+export const PackageManagers: ReadonlySet<PackageManager> = new Set([
+  PackageManager.NPM,
+  PackageManager.YARN,
+  PackageManager.PNPM,
+]);

--- a/src/process/exit.ts
+++ b/src/process/exit.ts
@@ -1,12 +1,12 @@
-import { printError } from "../io/printError";
-import { printText } from "../io/printText";
+import { printError } from '../io/printError';
+import { printText } from '../io/printText';
 
 export function exit(status: 'ok' | 'error' = 'ok', reason?: string): never {
   const code = status === 'ok' ? 0 : 1;
 
   if (reason) {
     const printer = status === 'ok' ? printText : printError;
-    
+
     printer(reason);
   }
 

--- a/src/process/getNodeVersion.test.ts
+++ b/src/process/getNodeVersion.test.ts
@@ -1,7 +1,7 @@
-import { getNodeVersion } from "./getNodeVersion";
+import { getNodeVersion } from './getNodeVersion';
 
 describe('process/getNodeVersion', () => {
   it('returns "process.version" value', () => {
     expect(getNodeVersion()).toBe(process.version);
-  })
+  });
 });

--- a/src/subEntryPoints/command.test.ts
+++ b/src/subEntryPoints/command.test.ts
@@ -19,7 +19,10 @@ describe('subEntryPoints/command', () => {
 
     await run(process.argv, 'custom');
 
-    expect(runCommandModuleMock).toHaveBeenCalledWith(process.argv, 'customCommand');
+    expect(runCommandModuleMock).toHaveBeenCalledWith(
+      process.argv,
+      'customCommand',
+    );
   });
 
   it('should call runCommandModule with the default command name when requested command name is not provided', async () => {
@@ -43,6 +46,8 @@ describe('subEntryPoints/command', () => {
   it('should throw an error when unable to read commandsMap.json', async () => {
     readFileMock.mockRejectedValue(new Error('Unable to read file'));
 
-    await expect(() => run(process.argv)).rejects.toThrow('Unable to read command list');
+    await expect(() => run(process.argv)).rejects.toThrow(
+      'Unable to read command list',
+    );
   });
 });

--- a/src/subEntryPoints/command.ts
+++ b/src/subEntryPoints/command.ts
@@ -7,14 +7,22 @@ export default async function run(
 ): Promise<void> {
   const commandName = await getCommandName(requestedCommandName);
 
-  const { runCommandModule } = await import('../commandHandler/runCommandModule');
+  const { runCommandModule } = await import(
+    '../commandHandler/runCommandModule'
+  );
 
   await runCommandModule(argv, commandName);
 }
 
 async function getCommandName(requestedCommandName = 'run'): Promise<string> {
   try {
-    const commandsMapFileLocation = resolve(__dirname, '..', '..', 'generated', 'commandsMap.json');
+    const commandsMapFileLocation = resolve(
+      __dirname,
+      '..',
+      '..',
+      'generated',
+      'commandsMap.json',
+    );
     const commandsMapText = await readFile(commandsMapFileLocation, 'utf-8');
     const commandsMap = JSON.parse(commandsMapText);
 

--- a/src/subEntryPoints/help.test.ts
+++ b/src/subEntryPoints/help.test.ts
@@ -1,9 +1,9 @@
-import { readFile } from "fs/promises";
-import { resolve } from "path";
-import run from "./help";
-import { printText } from "../io/printText";
+import { readFile } from 'fs/promises';
+import { resolve } from 'path';
+import run from './help';
+import { printText } from '../io/printText';
 
-jest.mock("fs/promises", () => ({
+jest.mock('fs/promises', () => ({
   readFile: jest.fn(),
 }));
 
@@ -12,26 +12,32 @@ jest.mock('../io/printText');
 const readFileMock = jest.mocked(readFile);
 const printTextMock = jest.mocked(printText);
 
-describe("subEntryPoints/help", () => {
+describe('subEntryPoints/help', () => {
   afterEach(() => {
     jest.resetAllMocks();
   });
 
-  it("should read help information and print it to console", async () => {
-    const sampleHelpText = "Sample help information.";
-    const helpFileLocation = resolve(__dirname, "..", "..", "generated", "help.txt");
+  it('should read help information and print it to console', async () => {
+    const sampleHelpText = 'Sample help information.';
+    const helpFileLocation = resolve(
+      __dirname,
+      '..',
+      '..',
+      'generated',
+      'help.txt',
+    );
 
     readFileMock.mockResolvedValueOnce(sampleHelpText);
 
     await run();
 
-    expect(readFileMock).toHaveBeenCalledWith(helpFileLocation, "utf-8");
+    expect(readFileMock).toHaveBeenCalledWith(helpFileLocation, 'utf-8');
     expect(printTextMock).toHaveBeenCalledWith(sampleHelpText);
   });
 
-  it("should throw an error if unable to read help information", async () => {
-    readFileMock.mockRejectedValueOnce(new Error("File not found"));
+  it('should throw an error if unable to read help information', async () => {
+    readFileMock.mockRejectedValueOnce(new Error('File not found'));
 
-    await expect(run()).rejects.toThrow("Unable to read help information");
+    await expect(run()).rejects.toThrow('Unable to read help information');
   });
 });

--- a/src/subEntryPoints/help.ts
+++ b/src/subEntryPoints/help.ts
@@ -1,10 +1,16 @@
-import { readFile } from "fs/promises";
-import { resolve } from "path";
-import { printText } from "../io/printText";
+import { readFile } from 'fs/promises';
+import { resolve } from 'path';
+import { printText } from '../io/printText';
 
 export default async function run(): Promise<void> {
   try {
-    const helpFileLocation = resolve(__dirname, '..', '..', 'generated', 'help.txt');
+    const helpFileLocation = resolve(
+      __dirname,
+      '..',
+      '..',
+      'generated',
+      'help.txt',
+    );
     const helpText = await readFile(helpFileLocation, 'utf-8');
 
     printText(helpText);

--- a/src/subEntryPoints/version.test.ts
+++ b/src/subEntryPoints/version.test.ts
@@ -1,9 +1,9 @@
-import { readFile } from "fs/promises";
-import { resolve } from "path";
-import run from "./version";
-import { printText } from "../io/printText";
+import { readFile } from 'fs/promises';
+import { resolve } from 'path';
+import run from './version';
+import { printText } from '../io/printText';
 
-jest.mock("fs/promises", () => ({
+jest.mock('fs/promises', () => ({
   readFile: jest.fn(),
 }));
 
@@ -12,26 +12,32 @@ jest.mock('../io/printText');
 const readFileMock = jest.mocked(readFile);
 const printTextMock = jest.mocked(printText);
 
-describe("subEntryPoints/version", () => {
+describe('subEntryPoints/version', () => {
   afterEach(() => {
     jest.resetAllMocks();
   });
 
-  it("should read version information and print it to console", async () => {
-    const sampleVersionText = "1.0.0";
-    const versionFileLocation = resolve(__dirname, "..", "..", "generated", "version.txt");
+  it('should read version information and print it to console', async () => {
+    const sampleVersionText = '1.0.0';
+    const versionFileLocation = resolve(
+      __dirname,
+      '..',
+      '..',
+      'generated',
+      'version.txt',
+    );
 
     readFileMock.mockResolvedValueOnce(sampleVersionText);
 
     await run();
 
-    expect(readFileMock).toHaveBeenCalledWith(versionFileLocation, "utf-8");
+    expect(readFileMock).toHaveBeenCalledWith(versionFileLocation, 'utf-8');
     expect(printTextMock).toHaveBeenCalledWith(sampleVersionText);
   });
 
-  it("should throw an error if unable to read version information", async () => {
-    readFileMock.mockRejectedValueOnce(new Error("File not found"));
+  it('should throw an error if unable to read version information', async () => {
+    readFileMock.mockRejectedValueOnce(new Error('File not found'));
 
-    await expect(run()).rejects.toThrow("Unable to read version information");
+    await expect(run()).rejects.toThrow('Unable to read version information');
   });
 });

--- a/src/subEntryPoints/version.ts
+++ b/src/subEntryPoints/version.ts
@@ -4,7 +4,13 @@ import { printText } from '../io/printText';
 
 export default async function run(): Promise<void> {
   try {
-    const versionFileLocation = resolve(__dirname, '..', '..', 'generated', 'version.txt');
+    const versionFileLocation = resolve(
+      __dirname,
+      '..',
+      '..',
+      'generated',
+      'version.txt',
+    );
     const versionText = await readFile(versionFileLocation, 'utf-8');
 
     printText(versionText);


### PR DESCRIPTION
### Changelog

- Fixed licenses command for pnpm
- Added help aliases to match with entryPoint matcher
- Converted `jest.config.js` to `jest.config.ts`
- Added usage examples for `run` and `exec` commands
- Fix commands behavior with `--global` flag (`preferredPm` flag to use preferred package manager instead will be added later)
- Pretter working now




