### PR TITLE
Update to v1.3.0

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -20,3 +20,5 @@ rules:
 ignorePatterns:
   - 'node_modules'
   - 'dist'
+  - 'generated'
+  - 'scratch'

--- a/__tests__/commands.test.ts
+++ b/__tests__/commands.test.ts
@@ -2,8 +2,11 @@ import { getDefaultPackageManager } from '../src/config/getDefaultPackageManager
 import { getGlobalPackageManager } from '../src/config/getGlobalPackageManager';
 import { executeCommand } from '../src/io/executeCommand';
 import { execute as executeBin } from '../src/bin/unpm';
-import { PackageManager, PackageManagers } from '../src/packageManager/packageManager';
-import path from 'path'
+import {
+  PackageManager,
+  PackageManagers,
+} from '../src/packageManager/packageManager';
+import path from 'path';
 import { CommandTestSuite, TestCaseOutcome } from './types';
 import { readdirSync } from 'fs';
 import { printError } from '../src/io/printError';
@@ -59,10 +62,18 @@ interface ExecutionResult {
   status: 'ok' | 'error';
 }
 async function emulateUnpmCall(input: string): Promise<ExecutionResult> {
-  const binFileLocation = path.resolve(__dirname, '..', 'dist', 'bin', 'unpm.js');
-  const mockArgv = splitArgs(input.includes('unpm') ?
-    input.replace('unpm', binFileLocation) :
-    `${binFileLocation} ${input}`);
+  const binFileLocation = path.resolve(
+    __dirname,
+    '..',
+    'dist',
+    'bin',
+    'unpm.js',
+  );
+  const mockArgv = splitArgs(
+    input.includes('unpm')
+      ? input.replace('unpm', binFileLocation)
+      : `${binFileLocation} ${input}`,
+  );
 
   await executeBin([process.argv0, ...mockArgv]);
 
@@ -79,7 +90,9 @@ declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace jest {
     interface Matchers<R> {
-      toMatchExtended(matcher: string | RegExp | ((value: string) => boolean)): R;
+      toMatchExtended(
+        matcher: string | RegExp | ((value: string) => boolean),
+      ): R;
     }
   }
 }
@@ -88,34 +101,38 @@ expect.extend({
   toMatchExtended(
     this,
     actual: string,
-    matcher: string | RegExp | ((value: string) => boolean)
+    matcher: string | RegExp | ((value: string) => boolean),
   ) {
     if (typeof matcher === 'string' || matcher instanceof RegExp) {
       if (actual.match(matcher)) {
         return {
           pass: true,
-          message: () => `expected a string that does not match the provided matcher ("${matcher}"), but received "${actual}"`,
+          message: () =>
+            `expected a string that does not match the provided matcher ("${matcher}"), but received "${actual}"`,
         };
       }
 
       return {
         pass: false,
-        message: () => `expected a string that matches the provided matcher ("${matcher}"), but received "${actual}"`,
+        message: () =>
+          `expected a string that matches the provided matcher ("${matcher}"), but received "${actual}"`,
       };
     }
-  
+
     if (matcher(actual)) {
       return {
         pass: true,
-        message: () => `expected a string that does not match the provided matcher predicate, but received "${actual}"`,
+        message: () =>
+          `expected a string that does not match the provided matcher predicate, but received "${actual}"`,
       };
     }
 
     return {
       pass: false,
-      message: () => `expected a string that matches the provided matcher predicate, but received "${actual}"`,
+      message: () =>
+        `expected a string that matches the provided matcher predicate, but received "${actual}"`,
     };
-  }
+  },
 });
 
 describe('commands', () => {
@@ -124,99 +141,120 @@ describe('commands', () => {
   });
 
   const commandsTestSuitesFolderLocation = path.resolve(__dirname, 'commands');
-  const commandsTestSuites: CommandTestSuite[] = readdirSync(commandsTestSuitesFolderLocation)
+  const commandsTestSuites: CommandTestSuite[] = readdirSync(
+    commandsTestSuitesFolderLocation,
+  )
     .filter(file => !file.startsWith('_'))
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     .map(file => require(`./commands/${file}`).default)
     .filter((testSuite: CommandTestSuite) => testSuite.testCases.length > 0);
-  
-  describe.each(commandsTestSuites)('"$commandName" command', ({ testCases }) => {
-    for (const { input: testCaseInput, expected, globalPm } of testCases) {
-      type InputSuiteMeta = {
-        input: string;
-        globalPm: PackageManager | null;
-        expected: Record<PackageManager, TestCaseOutcome>;
+
+  describe.each(commandsTestSuites)(
+    '"$commandName" command',
+    ({ testCases }) => {
+      for (const { input: testCaseInput, expected, globalPm } of testCases) {
+        type InputSuiteMeta = {
+          input: string;
+          globalPm: PackageManager | null;
+          expected: Record<PackageManager, TestCaseOutcome>;
+        };
+
+        const inputs: InputSuiteMeta[] = Array.isArray(testCaseInput)
+          ? testCaseInput.reduce((acc, input) => {
+              if (globalPm) {
+                acc.push(
+                  ...[...PackageManagers].map(packageManager => ({
+                    expected: [...PackageManagers].reduce((newExpected, i) => {
+                      newExpected[i] = expected[packageManager];
+
+                      return newExpected;
+                    }, {} as Record<PackageManager, TestCaseOutcome>),
+                    globalPm: packageManager,
+                    input,
+                  })),
+                );
+              }
+
+              acc.push({
+                expected,
+                globalPm: null,
+                input,
+              });
+
+              return acc;
+            }, [] as InputSuiteMeta[])
+          : globalPm
+          ? [
+              ...[...PackageManagers].map(packageManager => ({
+                expected: [...PackageManagers].reduce((newExpected, i) => {
+                  newExpected[i] = expected[packageManager];
+
+                  return newExpected;
+                }, {} as Record<PackageManager, TestCaseOutcome>),
+                globalPm: packageManager,
+                input: testCaseInput,
+              })),
+              {
+                expected,
+                globalPm: null,
+                input: testCaseInput,
+              },
+            ]
+          : [
+              {
+                expected,
+                globalPm: null,
+                input: testCaseInput,
+              },
+            ];
+
+        const inputSuiteText = globalPm
+          ? `input (globalPm: $globalPm): "$input"`
+          : 'input: "$input"';
+
+        describe.each(inputs)(inputSuiteText, testCase => {
+          const testCases = [...PackageManagers].map(packageManager => ({
+            packageManager,
+            ...testCase,
+            expected: testCase.expected[packageManager],
+          }));
+          it.each(testCases)(
+            'package manager: "$packageManager" - $expected',
+            async ({ packageManager }) => {
+              getDefaultPackageManagerMock.mockResolvedValue(packageManager);
+              getGlobalPackageManagerMock.mockResolvedValue(testCase.globalPm);
+              const expected = testCase.expected[packageManager];
+
+              const result = await emulateUnpmCall(testCase.input);
+
+              if ('expectedGeneratedCommand' in expected) {
+                const generatedCommand = executeCommandMock.mock.calls[0]?.[0];
+
+                if (testCase.globalPm) {
+                  expect(getGlobalPackageManagerMock).toHaveBeenCalledTimes(1);
+                  expect(getDefaultPackageManagerMock).toHaveBeenCalledTimes(0);
+                }
+                expect(generatedCommand).toMatchExtended(
+                  expected.expectedGeneratedCommand,
+                );
+                expect(result.status).toBe('ok');
+                expect(executeCommandMock).toHaveBeenCalled();
+              } else {
+                const errorMessages = printErrorMock.mock.calls.map(
+                  ([message]) =>
+                    typeof message === 'string' ? message : String(message),
+                );
+
+                expect(errorMessages[0]).toMatchExtended(
+                  expected.expectedErrorOutput,
+                );
+                expect(result.status).toBe('error');
+                expect(executeCommandMock).not.toHaveBeenCalled();
+              }
+            },
+          );
+        });
       }
-
-      const inputs: InputSuiteMeta[] = Array.isArray(testCaseInput) ? testCaseInput.reduce((acc, input) => {
-        if (globalPm) {
-          acc.push(...[...PackageManagers].map(packageManager => ({
-            expected: [...PackageManagers].reduce((newExpected, i) => {
-              newExpected[i] = expected[packageManager];
-
-              return newExpected;
-            }, {} as Record<PackageManager, TestCaseOutcome>),
-            globalPm: packageManager,
-            input,
-          })));
-        }
-
-        acc.push({
-          expected,
-          globalPm: null,
-          input,
-        });
-
-        return acc;
-      }, [] as InputSuiteMeta[]) : (
-        globalPm ?
-        [
-          ...[...PackageManagers].map(packageManager => ({
-            expected: [...PackageManagers].reduce((newExpected, i) => {
-              newExpected[i] = expected[packageManager];
-
-              return newExpected;
-            }, {} as Record<PackageManager, TestCaseOutcome>),
-            globalPm: packageManager,
-            input: testCaseInput,
-          })),
-          {
-            expected,
-            globalPm: null,
-            input: testCaseInput,
-          }
-        ] :
-        [{
-          expected,
-          globalPm: null,
-          input: testCaseInput,
-        }]
-      );
-
-      const inputSuiteText = globalPm ? `input (globalPm: $globalPm): "$input"` : 'input: "$input"';
-
-      describe.each(inputs)(inputSuiteText, (testCase) => {
-        const testCases = [...PackageManagers].map(packageManager => ({
-          packageManager,
-          ...testCase,
-          expected: testCase.expected[packageManager],
-        }));
-        it.each(testCases)('package manager: "$packageManager" - $expected', async ({ packageManager }) => {
-          getDefaultPackageManagerMock.mockResolvedValue(packageManager);
-          getGlobalPackageManagerMock.mockResolvedValue(testCase.globalPm);
-          const expected = testCase.expected[packageManager];
-
-          const result = await emulateUnpmCall(testCase.input);
-
-          if ('expectedGeneratedCommand' in expected) {
-            const generatedCommand = executeCommandMock.mock.calls[0]?.[0];
-
-            if (testCase.globalPm) {
-              expect(getGlobalPackageManagerMock).toHaveBeenCalledTimes(1);
-              expect(getDefaultPackageManagerMock).toHaveBeenCalledTimes(0);
-            }
-            expect(generatedCommand).toMatchExtended(expected.expectedGeneratedCommand);
-            expect(result.status).toBe('ok');
-            expect(executeCommandMock).toHaveBeenCalled();
-          } else {
-            const errorMessages = printErrorMock.mock.calls.map(([message]) => typeof message === 'string' ? message : String(message));
-
-            expect(errorMessages[0]).toMatchExtended(expected.expectedErrorOutput);
-            expect(result.status).toBe('error');
-            expect(executeCommandMock).not.toHaveBeenCalled();
-          }
-        });
-      });
-    }
-  });
-})
+    },
+  );
+});

--- a/__tests__/commands/_template.ts
+++ b/__tests__/commands/_template.ts
@@ -1,5 +1,5 @@
 import { PackageManager } from '../../src/packageManager/packageManager';
-import { CommandTestSuite } from "../types";
+import { CommandTestSuite } from '../types';
 
 const testSuite: CommandTestSuite = {
   commandName: '{{command}}',

--- a/__tests__/commands/audit.ts
+++ b/__tests__/commands/audit.ts
@@ -1,5 +1,5 @@
 import { PackageManager } from '../../src/packageManager/packageManager';
-import { CommandTestSuite } from "../types";
+import { CommandTestSuite } from '../types';
 
 const testSuite: CommandTestSuite = {
   commandName: 'audit',
@@ -53,7 +53,8 @@ const testSuite: CommandTestSuite = {
           expectedGeneratedCommand: 'npm audit --only=prod --only=dev',
         },
         [PackageManager.YARN]: {
-          expectedGeneratedCommand: 'yarn audit --groups="dependencies devDependencies"',
+          expectedGeneratedCommand:
+            'yarn audit --groups="dependencies devDependencies"',
         },
         [PackageManager.PNPM]: {
           expectedGeneratedCommand: 'pnpm audit --prod --dev',

--- a/__tests__/commands/bin.ts
+++ b/__tests__/commands/bin.ts
@@ -1,5 +1,5 @@
 import { PackageManager } from '../../src/packageManager/packageManager';
-import { CommandTestSuite } from "../types";
+import { CommandTestSuite } from '../types';
 
 const testSuite: CommandTestSuite = {
   commandName: 'bin',

--- a/__tests__/commands/dlx.ts
+++ b/__tests__/commands/dlx.ts
@@ -1,7 +1,8 @@
 import { PackageManager } from '../../src/packageManager/packageManager';
-import { CommandTestSuite } from "../types";
+import { CommandTestSuite } from '../types';
 
-const errorMessage = '"dlx" command is not implemented by unpm, ' +
+const errorMessage =
+  '"dlx" command is not implemented by unpm, ' +
   'please use your package manager directly for it';
 
 const testSuite: CommandTestSuite = {
@@ -20,7 +21,7 @@ const testSuite: CommandTestSuite = {
           expectedErrorOutput: errorMessage,
         },
       },
-    }
+    },
   ],
 };
 

--- a/__tests__/commands/exec.ts
+++ b/__tests__/commands/exec.ts
@@ -1,5 +1,5 @@
 import { PackageManager } from '../../src/packageManager/packageManager';
-import { CommandTestSuite } from "../types";
+import { CommandTestSuite } from '../types';
 
 const testSuite: CommandTestSuite = {
   commandName: 'exec',
@@ -22,7 +22,8 @@ const testSuite: CommandTestSuite = {
       input: 'unpm exec cmd --option positional --opt=3',
       expected: {
         [PackageManager.NPM]: {
-          expectedGeneratedCommand: 'npm exec -- cmd --option positional --opt=3',
+          expectedGeneratedCommand:
+            'npm exec -- cmd --option positional --opt=3',
         },
         [PackageManager.YARN]: {
           expectedGeneratedCommand: 'yarn run cmd --option positional --opt=3',

--- a/__tests__/commands/init.ts
+++ b/__tests__/commands/init.ts
@@ -1,5 +1,5 @@
 import { PackageManager } from '../../src/packageManager/packageManager';
-import { CommandTestSuite } from "../types";
+import { CommandTestSuite } from '../types';
 
 const testSuite: CommandTestSuite = {
   commandName: 'init',

--- a/__tests__/commands/install.ts
+++ b/__tests__/commands/install.ts
@@ -1,5 +1,5 @@
 import { PackageManager } from '../../src/packageManager/packageManager';
-import { CommandTestSuite } from "../types";
+import { CommandTestSuite } from '../types';
 
 const testSuite: CommandTestSuite = {
   commandName: 'install',
@@ -47,7 +47,11 @@ const testSuite: CommandTestSuite = {
       },
     },
     {
-      input: ['unpm install express --save', 'unpm install express --save-prod', 'unpm install express -S'],
+      input: [
+        'unpm install express --save',
+        'unpm install express --save-prod',
+        'unpm install express -S',
+      ],
       expected: {
         [PackageManager.NPM]: {
           expectedGeneratedCommand: 'npm install express --save',
@@ -61,7 +65,11 @@ const testSuite: CommandTestSuite = {
       },
     },
     {
-      input: ['unpm install express --save', 'unpm install express --save-prod', 'unpm install express -S'],
+      input: [
+        'unpm install express --save',
+        'unpm install express --save-prod',
+        'unpm install express -S',
+      ],
       expected: {
         [PackageManager.NPM]: {
           expectedGeneratedCommand: 'npm install express --save',
@@ -75,7 +83,11 @@ const testSuite: CommandTestSuite = {
       },
     },
     {
-      input: ['unpm install express --save-dev', 'unpm install express --dev', 'unpm install express -D'],
+      input: [
+        'unpm install express --save-dev',
+        'unpm install express --dev',
+        'unpm install express -D',
+      ],
       expected: {
         [PackageManager.NPM]: {
           expectedGeneratedCommand: 'npm install express --save-dev',
@@ -92,7 +104,7 @@ const testSuite: CommandTestSuite = {
       input: [
         'unpm install express --save-exact',
         'unpm install express --exact',
-        'unpm install express -E'
+        'unpm install express -E',
       ],
       expected: {
         [PackageManager.NPM]: {
@@ -110,7 +122,7 @@ const testSuite: CommandTestSuite = {
       input: [
         'unpm install express --save-optional',
         'unpm install express --optional',
-        'unpm install express -O'
+        'unpm install express -O',
       ],
       expected: {
         [PackageManager.NPM]: {
@@ -128,7 +140,7 @@ const testSuite: CommandTestSuite = {
       input: [
         'unpm install express --save-peer',
         'unpm install express --peer',
-        'unpm install express -P'
+        'unpm install express -P',
       ],
       expected: {
         [PackageManager.NPM]: {
@@ -143,10 +155,7 @@ const testSuite: CommandTestSuite = {
       },
     },
     {
-      input: [
-        'unpm install express --global',
-        'unpm install express -g',
-      ],
+      input: ['unpm install express --global', 'unpm install express -g'],
       globalPm: true,
       expected: {
         [PackageManager.NPM]: {

--- a/__tests__/commands/licenses.ts
+++ b/__tests__/commands/licenses.ts
@@ -1,5 +1,5 @@
 import { PackageManager } from '../../src/packageManager/packageManager';
-import { CommandTestSuite } from "../types";
+import { CommandTestSuite } from '../types';
 
 const testSuite: CommandTestSuite = {
   commandName: 'licenses',
@@ -8,7 +8,8 @@ const testSuite: CommandTestSuite = {
       input: 'unpm licenses',
       expected: {
         [PackageManager.NPM]: {
-          expectedErrorOutput: /NotSupportedError: "licenses" is not supported by npm/i,
+          expectedErrorOutput:
+            /NotSupportedError: "licenses" is not supported by npm/i,
         },
         [PackageManager.YARN]: {
           expectedGeneratedCommand: 'yarn licenses list',
@@ -18,7 +19,6 @@ const testSuite: CommandTestSuite = {
         },
       },
     },
-
   ],
 };
 

--- a/__tests__/commands/link.ts
+++ b/__tests__/commands/link.ts
@@ -1,5 +1,5 @@
 import { PackageManager } from '../../src/packageManager/packageManager';
-import { CommandTestSuite } from "../types";
+import { CommandTestSuite } from '../types';
 
 const testSuite: CommandTestSuite = {
   commandName: 'link',

--- a/__tests__/commands/list.ts
+++ b/__tests__/commands/list.ts
@@ -1,5 +1,5 @@
 import { PackageManager } from '../../src/packageManager/packageManager';
-import { CommandTestSuite } from "../types";
+import { CommandTestSuite } from '../types';
 
 const testSuite: CommandTestSuite = {
   commandName: 'list',

--- a/__tests__/commands/outdated.ts
+++ b/__tests__/commands/outdated.ts
@@ -1,5 +1,5 @@
 import { PackageManager } from '../../src/packageManager/packageManager';
-import { CommandTestSuite } from "../types";
+import { CommandTestSuite } from '../types';
 
 const testSuite: CommandTestSuite = {
   commandName: 'outdated',

--- a/__tests__/commands/pack.ts
+++ b/__tests__/commands/pack.ts
@@ -1,5 +1,5 @@
 import { PackageManager } from '../../src/packageManager/packageManager';
-import { CommandTestSuite } from "../types";
+import { CommandTestSuite } from '../types';
 
 const testSuite: CommandTestSuite = {
   commandName: 'pack',
@@ -26,13 +26,16 @@ const testSuite: CommandTestSuite = {
       ],
       expected: {
         [PackageManager.NPM]: {
-          expectedGeneratedCommand: 'npm pack --pack-destination=path/to/something',
+          expectedGeneratedCommand:
+            'npm pack --pack-destination=path/to/something',
         },
         [PackageManager.YARN]: {
-          expectedErrorOutput: '"pack --pack-destination <dir>" is not supported by yarn',
+          expectedErrorOutput:
+            '"pack --pack-destination <dir>" is not supported by yarn',
         },
         [PackageManager.PNPM]: {
-          expectedGeneratedCommand: 'pnpm pack --pack-destination=path/to/something',
+          expectedGeneratedCommand:
+            'pnpm pack --pack-destination=path/to/something',
         },
       },
     },

--- a/__tests__/commands/publish.ts
+++ b/__tests__/commands/publish.ts
@@ -1,7 +1,8 @@
 import { PackageManager } from '../../src/packageManager/packageManager';
-import { CommandTestSuite } from "../types";
+import { CommandTestSuite } from '../types';
 
-const errorMessage = '"publish" command is not implemented by unpm, ' +
+const errorMessage =
+  '"publish" command is not implemented by unpm, ' +
   'please use your package manager directly for it';
 
 const testSuite: CommandTestSuite = {
@@ -20,7 +21,7 @@ const testSuite: CommandTestSuite = {
           expectedErrorOutput: errorMessage,
         },
       },
-    }
+    },
   ],
 };
 

--- a/__tests__/commands/rebuild.ts
+++ b/__tests__/commands/rebuild.ts
@@ -1,5 +1,5 @@
 import { PackageManager } from '../../src/packageManager/packageManager';
-import { CommandTestSuite } from "../types";
+import { CommandTestSuite } from '../types';
 
 const testSuite: CommandTestSuite = {
   commandName: 'rebuild',

--- a/__tests__/commands/run.ts
+++ b/__tests__/commands/run.ts
@@ -1,5 +1,5 @@
 import { PackageManager } from '../../src/packageManager/packageManager';
-import { CommandTestSuite } from "../types";
+import { CommandTestSuite } from '../types';
 
 const testSuite: CommandTestSuite = {
   commandName: 'run',
@@ -50,13 +50,16 @@ const testSuite: CommandTestSuite = {
       input: 'unpm cmd --optional positional --opt=2',
       expected: {
         [PackageManager.NPM]: {
-          expectedGeneratedCommand: 'npm run cmd -- --optional positional --opt=2',
+          expectedGeneratedCommand:
+            'npm run cmd -- --optional positional --opt=2',
         },
         [PackageManager.YARN]: {
-          expectedGeneratedCommand: 'yarn run cmd --optional positional --opt=2',
+          expectedGeneratedCommand:
+            'yarn run cmd --optional positional --opt=2',
         },
         [PackageManager.PNPM]: {
-          expectedGeneratedCommand: 'pnpm run cmd --optional positional --opt=2',
+          expectedGeneratedCommand:
+            'pnpm run cmd --optional positional --opt=2',
         },
       },
     },

--- a/__tests__/commands/uninstall.ts
+++ b/__tests__/commands/uninstall.ts
@@ -1,5 +1,5 @@
 import { PackageManager } from '../../src/packageManager/packageManager';
-import { CommandTestSuite } from "../types";
+import { CommandTestSuite } from '../types';
 
 const testSuite: CommandTestSuite = {
   commandName: 'uninstall',
@@ -8,13 +8,16 @@ const testSuite: CommandTestSuite = {
       input: 'unpm remove',
       expected: {
         [PackageManager.NPM]: {
-          expectedErrorOutput: 'Not enough non-option arguments: got 0, need at least 1',
+          expectedErrorOutput:
+            'Not enough non-option arguments: got 0, need at least 1',
         },
         [PackageManager.YARN]: {
-          expectedErrorOutput: 'Not enough non-option arguments: got 0, need at least 1',
+          expectedErrorOutput:
+            'Not enough non-option arguments: got 0, need at least 1',
         },
         [PackageManager.PNPM]: {
-          expectedErrorOutput: 'Not enough non-option arguments: got 0, need at least 1',
+          expectedErrorOutput:
+            'Not enough non-option arguments: got 0, need at least 1',
         },
       },
     },

--- a/__tests__/commands/unlink.ts
+++ b/__tests__/commands/unlink.ts
@@ -1,5 +1,5 @@
 import { PackageManager } from '../../src/packageManager/packageManager';
-import { CommandTestSuite } from "../types";
+import { CommandTestSuite } from '../types';
 
 const testSuite: CommandTestSuite = {
   commandName: 'unlink',

--- a/__tests__/commands/update.ts
+++ b/__tests__/commands/update.ts
@@ -1,5 +1,5 @@
 import { PackageManager } from '../../src/packageManager/packageManager';
-import { CommandTestSuite } from "../types";
+import { CommandTestSuite } from '../types';
 
 const testSuite: CommandTestSuite = {
   commandName: 'update',
@@ -19,11 +19,7 @@ const testSuite: CommandTestSuite = {
       },
     },
     {
-      input: [
-        'unpm update express',
-        'unpm upgrade express',
-        'unpm up express',
-      ],
+      input: ['unpm update express', 'unpm upgrade express', 'unpm up express'],
       expected: {
         [PackageManager.NPM]: {
           expectedGeneratedCommand: 'npm update express',

--- a/__tests__/commands/version.ts
+++ b/__tests__/commands/version.ts
@@ -1,5 +1,5 @@
 import { PackageManager } from '../../src/packageManager/packageManager';
-import { CommandTestSuite } from "../types";
+import { CommandTestSuite } from '../types';
 
 const testSuite: CommandTestSuite = {
   commandName: 'version',

--- a/__tests__/commands/why.ts
+++ b/__tests__/commands/why.ts
@@ -1,5 +1,5 @@
 import { PackageManager } from '../../src/packageManager/packageManager';
-import { CommandTestSuite } from "../types";
+import { CommandTestSuite } from '../types';
 
 const testSuite: CommandTestSuite = {
   commandName: 'why',
@@ -8,13 +8,16 @@ const testSuite: CommandTestSuite = {
       input: 'unpm why',
       expected: {
         [PackageManager.NPM]: {
-          expectedErrorOutput: 'Not enough non-option arguments: got 0, need at least 1',
+          expectedErrorOutput:
+            'Not enough non-option arguments: got 0, need at least 1',
         },
         [PackageManager.YARN]: {
-          expectedErrorOutput: 'Not enough non-option arguments: got 0, need at least 1',
+          expectedErrorOutput:
+            'Not enough non-option arguments: got 0, need at least 1',
         },
         [PackageManager.PNPM]: {
-          expectedErrorOutput: 'Not enough non-option arguments: got 0, need at least 1',
+          expectedErrorOutput:
+            'Not enough non-option arguments: got 0, need at least 1',
         },
       },
     },

--- a/__tests__/types.ts
+++ b/__tests__/types.ts
@@ -1,4 +1,4 @@
-import { PackageManager } from "../src/packageManager/packageManager";
+import { PackageManager } from '../src/packageManager/packageManager';
 
 export interface TestCaseOutcome__Success {
   expectedGeneratedCommand: string | RegExp | ((value: string) => boolean);

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -4,12 +4,10 @@ import { readFileSync } from 'fs';
 const swcConfig = JSON.parse(readFileSync(`${__dirname}/.swcrc`, 'utf-8'));
 
 const config: Config.InitialOptions = {
-  testMatch: [
-    "**/*.test.ts",
-  ],
+  testMatch: ['**/*.test.ts'],
   transform: {
-    "^.+\\.ts$": [
-      "@swc/jest",
+    '^.+\\.ts$': [
+      '@swc/jest',
       {
         ...swcConfig,
         exclude: [],

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "typecheck:watch": "tsc --watch --incremental",
     "pregenerate-files": "ts-node scripts/pregenerate-files.ts",
     "pregenerate-files:watch": "nodemon --exec \"npm run pregenerate-files\" --watch dist",
-    "lint": "eslint src/**/* scripts/**/*",
+    "lint": "eslint src/**/* scripts/**/* __tests__/**/*",
     "release": "ts-node scripts/release.ts",
     "create-command": "ts-node scripts/create-command.ts"
   },


### PR DESCRIPTION
### Changelog

- 

### TODO

- Add `preferredPm` flag for global commands to use preferred package manager instead of global one.
- Add global option for printing generated command. And for only printing (without executing it)
- 